### PR TITLE
Add release scripts and tag-on-main guard

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -14,6 +14,11 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+      - name: Verify tag is on main
+        run: |
+          git fetch origin main
+          git merge-base --is-ancestor $GITHUB_SHA origin/main || \
+            (echo "Error: tag is not on main branch" && exit 1)
       - name: Generate release notes
         run: |
           TAG="${GITHUB_REF#refs/tags/}"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsc",
-    "test": "jest"
+    "test": "jest",
+    "release:patch": "npm version patch && git push origin main --follow-tags",
+    "release:minor": "npm version minor && git push origin main --follow-tags",
+    "release:major": "npm version major && git push origin main --follow-tags"
   },
   "devDependencies": {
     "colorjs.io": "^0.5.2",


### PR DESCRIPTION
- Add release:patch/minor/major scripts to package.json using npm version and git push --follow-tags for atomic, fail-loud releases
- Add "Verify tag is on main" step to draft-release.yml to reject tags not reachable from main before creating a draft release

https://claude.ai/code/session_014zSwEgy9pM8aa4MqXas2xX