### PR TITLE
docs: author all docs/ math in LaTeX, fix GitHub-broken spans

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,24 +33,45 @@ Shared symbols, so the docs read as one notation: $L^3$, $\delta$, $Y$,
 $Y_{\text{lighter}}$ / $Y_{\text{darker}}$ (OKCA proxies) vs $Y_l$ / $Y_d$
 (WCAG luminances), $r_{\text{raw}}$, $\text{CAP}$, $k$, $A(l)$, $B(d)$.
 
-Four rules the `docs-lint.spec.ts` suite enforces across every `docs/*.md`:
+### The one thing to understand
 
-1. **`\texttt{}` must never appear inside `$...$`.** The renderer treats `_` as
-   a subscript operator even inside `\texttt{}`. Split the span instead:
+GitHub runs its **Markdown pass first**, then hands the result to KaTeX. So
+Markdown rewrites your TeX before the renderer ever sees it. Every rule below
+follows from that, and none of it is visible locally — only on github.com.
 
-   ```latex
-   $k =$ `POL_K` $= 1.100$      % CORRECT
-   $k = \texttt{POL\_K} = 1.1$  % WRONG — "'_' allowed only in math mode"
-   ```
+**A multi-line `$$` block is passed through literally and is exempt.** A
+single-line `$$...$$` is not: it is processed like any other inline content.
 
-2. **Balanced `$` on every line.** An inline span may not wrap onto the next
-   line — GitHub will not render it. Reflow it onto one line.
-3. **Use `\lbrace` / `\rbrace`, never `\{` / `\}`.** Markdown consumes the
-   backslash-escape before KaTeX sees it, silently turning literal set braces
-   into grouping.
-4. Code stays code: constant identifiers, function names, CLI commands, and hex
-   colours belong in backticks, not math. The exception is a constant appearing
-   as a quantity inside an equation, where `\text{LOD\_CAP}` (`\text`, escaped
-   underscore) is used.
+Rules `docs-lint.spec.ts` enforces across every `docs/*.md`:
+
+1. **No backslash-escaped punctuation inside single-line math.** Markdown eats
+   the backslash. `\_`→`_` and `\%`→`%` become hard KaTeX parse errors; `\,`→`,`
+   `\;`→`;` `\\`→`\` silently render the wrong glyph. Letter-named commands
+   survive, so use `\thinspace`, `\quad`, `\lbrace`, `\rbrace`. For `\\` row
+   breaks, write the `$$` block across multiple lines.
+2. **Never put a constant name inside math.** `\texttt{POL\_K}` and
+   `\text{POL\_K}` both break — the escaped underscore does not survive. Split
+   the span: `` $k =$ `POL_K` $= 1.100$ ``. If the constant is a quantity in an
+   equation, give it a symbol (`$c$` for the L-o-D cap in `FP0_PROOF.md`) or
+   inline its value.
+3. **No `$` jammed against `"`, `-`, `/`, or a single `*`.** GitHub then fails
+   to recognise the span at all and prints literal `$...$`. Add a space or
+   reword. Bold `**` is fine.
+4. **Balanced `$` on every line.** An inline span may not wrap onto the next
+   line — GitHub will not render it. Reflow it.
+5. Code stays code: constant identifiers, function names, CLI commands, and hex
+   colours belong in backticks, not math.
 
 Headings stay plain text — math in a heading mangles its anchor.
+
+**Verifying a change.** The lint catches the known traps, but it is not a
+renderer. To check real output, POST the file to GitHub's markdown API and parse
+what comes back:
+
+```sh
+gh api -X POST markdown -f mode=gfm -f text="$(cat docs/FP0_PROOF.md)"
+```
+
+Math arrives as `<math-renderer>` elements holding the post-Markdown TeX — that
+string, not your source, is what KaTeX receives. A span missing from the output
+entirely was not recognised as math (rule 3).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,16 +23,34 @@ and the WCAG disagreement counts. Probe test expectations
 (`okca-oracle.spec.ts`), and the FP=0 verifier (`npm run fp0`, which must
 still certify with 0 uncertified boxes) must also be updated/re-run.
 
-### LaTeX rule — `\texttt{}` must never appear inside `$...$`
+## Math notation in `docs/`
 
-When writing a constant name inline with an equation, split the math:
+All maths in `docs/*.md` is authored in LaTeX (`$...$` inline, `$$...$$`
+display) and rendered by GitHub with KaTeX. Do not introduce ASCII or Unicode
+formulas (`L³`, `δ = L³ − Y`, `21^(1−k)·A(white)`) — convert them.
 
-```latex
-% CORRECT
-$k =$ \texttt{POL\_K} $= 1.100$
+Shared symbols, so the docs read as one notation: $L^3$, $\delta$, $Y$,
+$Y_{\text{lighter}}$ / $Y_{\text{darker}}$ (OKCA proxies) vs $Y_l$ / $Y_d$
+(WCAG luminances), $r_{\text{raw}}$, $\text{CAP}$, $k$, $A(l)$, $B(d)$.
 
-% WRONG — causes "'_' allowed only in math mode"
-$k = \texttt{POL\_K} = 1.100$
-```
+Four rules the `docs-lint.spec.ts` suite enforces across every `docs/*.md`:
 
-A test in `docs-lint.spec.ts` enforces this automatically.
+1. **`\texttt{}` must never appear inside `$...$`.** The renderer treats `_` as
+   a subscript operator even inside `\texttt{}`. Split the span instead:
+
+   ```latex
+   $k =$ `POL_K` $= 1.100$      % CORRECT
+   $k = \texttt{POL\_K} = 1.1$  % WRONG — "'_' allowed only in math mode"
+   ```
+
+2. **Balanced `$` on every line.** An inline span may not wrap onto the next
+   line — GitHub will not render it. Reflow it onto one line.
+3. **Use `\lbrace` / `\rbrace`, never `\{` / `\}`.** Markdown consumes the
+   backslash-escape before KaTeX sees it, silently turning literal set braces
+   into grouping.
+4. Code stays code: constant identifiers, function names, CLI commands, and hex
+   colours belong in backticks, not math. The exception is a constant appearing
+   as a quantity inside an equation, where `\text{LOD\_CAP}` (`\text`, escaped
+   underscore) is used.
+
+Headings stay plain text — math in a heading mangles its anchor.

--- a/docs/CALIBRATION_EXPERIMENT.md
+++ b/docs/CALIBRATION_EXPERIMENT.md
@@ -47,7 +47,7 @@ the anchors pins two of them:
 
 - white/#767676 → 3.5 (L-o-D) **pins `POL_K = 1.175`**.
 - black/white → 20.0 (D-o-L) **pins `DOL_CAP = 20`** — that pair evaluates to
-  $\text{CAP} \cdot (21/21)^{k} = \text{DOL\_CAP}$.
+  $\text{CAP} \cdot (21/21)^{k} = \text{CAP} = 20$.
 
 So under constraints (2)+(4) the only genuinely free knobs are **`C_THRESH` and
 `CHROMA_K`** — the lighter-element chroma penalty (`chromaExp`,
@@ -91,11 +91,9 @@ without editing source.
 `contrast()` on all design-system pairs + 5,000 random pairs — **0 mismatches**.
 It reproduces the documented baseline exactly:
 
-- FP count (strong: $\text{OKCA}_{\text{rounded}} > \text{WCAG}_{\text{rounded}}$)
-  over 2.79M pairs: **0**
-- worst overshoot
-  $\max(\text{OKCA}_{\text{raw}} - \text{WCAG}_{\text{raw}})$: **−0.0000** (the
-  white/black anchor)
+- FP count (strong: rounded $\text{OKCA} > \text{WCAG}$) over 2.79M pairs: **0**
+- worst overshoot, $\max(\text{OKCA} - \text{WCAG})$ on raw scores: **−0.0000**
+  (the white/black anchor)
 - design-system WCAG disagreements: **111** (matches `probe-design-systems.spec.ts`)
 
 ---

--- a/docs/CALIBRATION_EXPERIMENT.md
+++ b/docs/CALIBRATION_EXPERIMENT.md
@@ -47,12 +47,13 @@ the anchors pins two of them:
 
 - white/#767676 → 3.5 (L-o-D) **pins `POL_K = 1.175`**.
 - black/white → 20.0 (D-o-L) **pins `DOL_CAP = 20`** — that pair evaluates to
-  `cap * (21/21)^POL_K = DOL_CAP`.
+  $\text{CAP} \cdot (21/21)^{k} = \text{DOL\_CAP}$.
 
 So under constraints (2)+(4) the only genuinely free knobs are **`C_THRESH` and
 `CHROMA_K`** — the lighter-element chroma penalty (`chromaExp`,
-`src/index.ts:90-96`). Because every anchor is achromatic (`C=0 → exp=1`),
-retuning these two cannot move any anchor by construction.
+`src/index.ts:90-96`). Because every anchor is achromatic
+($C = 0 \Rightarrow \text{exp} = 1$), retuning these two cannot move any anchor
+by construction.
 
 ---
 
@@ -65,7 +66,7 @@ Three corrections shaped the harness instead:
    be the calibration target (OKCA deliberately undercuts it; calibrating toward
    it just reproduces WCAG). With no external perceptual model allowed, the only
    legitimate signal is the WCAG ceiling used **one-sidedly**: "reduce the
-   WCAG − OKCA gap wherever FP=0 does not require it."
+   $\text{WCAG} - \text{OKCA}$ gap wherever FP=0 does not require it."
 2. **Uniform *RGB* is the wrong space.** The free knobs act on **chroma** in
    OKLCH; most of sRGB's volume sits far from the 4.5/7.0 decision boundary and
    carries ~no calibration information. The harness samples a gamut-valid sRGB
@@ -90,16 +91,19 @@ without editing source.
 `contrast()` on all design-system pairs + 5,000 random pairs — **0 mismatches**.
 It reproduces the documented baseline exactly:
 
-- FP count (strong: OKCA_rounded > WCAG_rounded) over 2.79M pairs: **0**
-- worst overshoot `max(OKCA_raw − WCAG_raw)`: **−0.0000** (the white/black anchor)
+- FP count (strong: $\text{OKCA}_{\text{rounded}} > \text{WCAG}_{\text{rounded}}$)
+  over 2.79M pairs: **0**
+- worst overshoot
+  $\max(\text{OKCA}_{\text{raw}} - \text{WCAG}_{\text{raw}})$: **−0.0000** (the
+  white/black anchor)
 - design-system WCAG disagreements: **111** (matches `probe-design-systems.spec.ts`)
 
 ---
 
 ## 4. Result 1 — the free knobs cannot move the 111
 
-Grid search over `C_THRESH ∈ {0.15…0.30}` × `CHROMA_K ∈ {0.20…0.50}` (POL_K,
-DOL_CAP, anchors all fixed):
+Grid search over `C_THRESH` $\in \lbrace 0.15 \ldots 0.30 \rbrace$ × `CHROMA_K`
+$\in \lbrace 0.20 \ldots 0.50 \rbrace$ (`POL_K`, `DOL_CAP`, anchors all fixed):
 
 - **Every one of the 35 candidates holds FP=0** across all 2.79M pairs,
   including the green-darker stress band. Worst overshoot never leaves the
@@ -108,7 +112,7 @@ DOL_CAP, anchors all fixed):
   111.
 
 **Why:** every design-system pair is a colour paired with **white**, and white
-(L≈1) is always the *lighter* element. The chroma penalty acts only on the
+($L \approx 1$) is always the *lighter* element. The chroma penalty acts only on the
 lighter element, so it **never fires on any of the 111**. Those under-calls are
 driven by the *darker* element's chroma through the global `POL_K` compression —
 which the fixed anchors lock. The two in-scope knobs are orthogonal to the
@@ -142,7 +146,7 @@ the agreed constraints.**
 
 The 111 are governed by `POL_K`, pinned by the white/#767676 anchor. An
 out-of-scope, **measurement-only** probe (changes no source) raised that anchor
-and re-derived `POL_K = ln(target/21) / ln(raw₇₆₇/21)`, then re-checked FP=0
+and re-derived `POL_K` $= \ln(\text{target}/21) / \ln(r_{767}/21)$, then re-checked FP=0
 over the full 2.79M-pair corpus and disagreement recovery:
 
 | white/#767676 | POL_K | FP=0 held? | of 111 recovered |
@@ -190,7 +194,7 @@ L-o-D cap 21 are unchanged.
 
 **(a) Anchor: white/#767676 → 3.9 (`POL_K` 1.175 → 1.100).** Raised to 3.9 (a
 balanced point below the ~4.0–4.1 FP=0 wall). Exact derivation
-`POL_K = ln(3.9/21)/ln(4.54/21) ≈ 1.0996`, rounded to **1.100** (the value at
+`POL_K` $= \ln(3.9/21)/\ln(4.54/21) \approx 1.0996$, rounded to **1.100** (the value at
 which `contrast('#ffffff','#767676')` rounds to 3.9).
 
 **(b) Chroma penalty: `CHROMA_K` 0.50 → 0.65.** `POL_K` is global, so lowering
@@ -200,7 +204,7 @@ pink thinned from 3.7 to 4.1. Strengthening the chroma penalty re-docks vivid
 foregrounds to their intended sub-AA scores. This lever is **cleanly decoupled**
 from step (a): the penalty acts only on the *lighter* element, and every
 design-system disagreement pairs a colour with white (white is the lighter
-element), so the 97-count is untouched; achromatic anchors (C=0) are untouched;
+element), so the 97-count is untouched; achromatic anchors ($C = 0$) are untouched;
 and strengthening a penalty only *lowers* chromatic scores, so FP=0 is preserved
 by construction. `CHROMA_K = 0.65` was chosen as the value that restores dark
 orange to 4.2 and hot pink to 3.7 — their exact pre-recalibration scores — while
@@ -218,7 +222,7 @@ leaving light pastels (low chroma → small penalty) essentially unchanged.
   and light pastels still pass, unchanged.
 - **FP = 0 preserved**, verified at the final constants: the 2.79M-pair broad
   sweep (0 FP), a **106M-pair** dense green-darker adversarial scan (0 FP), and
-  the design-system `probe-design-systems.spec.ts` FP=0 test. `POL_K ≥ 1` keeps
+  the design-system `probe-design-systems.spec.ts` FP=0 test. `POL_K` $\ge 1$ keeps
   the achromatic FP=0-by-construction proof intact.
 
 All five synced docs, both probe specs, the oracle mirror, and this file were
@@ -233,7 +237,7 @@ This removes the single white-on-black equality point, so OKCA is *strictly*
 below WCAG everywhere and the interval verifier certifies the full gamut with 0
 uncertified boxes.
 
-Effect on the numbers above: all **light-on-dark** scores scale by 20.9/21
+Effect on the numbers above: all **light-on-dark** scores scale by $20.9/21$
 (dark-on-light, cap 20, is unchanged). So white/black = **20.9**, hot
 pink/near-black **3.7 → 3.6**; dark orange stays 4.2. The **disagreement count is
 unchanged at 97** (34/13/50), and no design-system pair flips. Cost measured by

--- a/docs/FP0_PROOF.md
+++ b/docs/FP0_PROOF.md
@@ -52,9 +52,10 @@ $\max B = B(\text{black})$.
 With $\text{CAP} = 21$ the bound at the anchor is $21/21 = 1$ — **tight**, so
 white-on-black would be the single point where $\text{OKCA} = \text{WCAG}$, which
 interval arithmetic cannot certify (it cannot prove a non-strict equality).
-Setting **`LOD_CAP` $= 20.9 < 21$** makes the anchor bound
+Setting **`LOD_CAP` $= 20.9 < 21$** — write $c$ for this cap — makes the anchor
+bound
 
-$$\frac{\text{LOD\_CAP}}{21^{k}} \cdot A(\text{white}) \cdot B(\text{black}) = \frac{\text{LOD\_CAP}}{21} = 0.99524 < 1,$$
+$$\frac{c}{21^{k}} \cdot A(\text{white}) \cdot B(\text{black}) = \frac{c}{21} = 0.99524 < 1,$$
 
 a **uniform strict margin**. There is now no equality point anywhere: OKCA is
 *strictly* below WCAG for every sRGB pair. (Dark-on-light, $\text{CAP} = 20$, is
@@ -70,9 +71,9 @@ $$\begin{aligned}
 \text{(L-B)} \quad & B(d) \le B(\text{black}) \cdot s && \text{for all sRGB } d,
 \end{aligned}$$
 
-with $s = \sqrt{21 / \text{LOD\_CAP}} = 1.00239$, since then
+with $s = \sqrt{21 / c} = 1.00239$, since then
 
-$$\frac{\text{LOD\_CAP}}{21^{k}} \cdot A \cdot B \le \frac{\text{LOD\_CAP}}{21^{k}} \cdot A(\text{white}) \cdot B(\text{black}) \cdot s^{2} = \frac{\text{LOD\_CAP}}{21} \cdot \frac{21}{\text{LOD\_CAP}} = 1.$$
+$$\frac{c}{21^{k}} \cdot A \cdot B \le \frac{c}{21^{k}} \cdot A(\text{white}) \cdot B(\text{black}) \cdot s^{2} = \frac{c}{21} \cdot \frac{21}{c} = 1.$$
 
 `scripts/fp0-proof.ts` branch-and-bounds each
 lemma over the sRGB cube with sound outward-rounded interval arithmetic
@@ -95,7 +96,7 @@ the anchors certify, so no neighbourhood is excluded.
 
 For every ordered sRGB pair:
 
-$$\frac{\text{LOD\_CAP}}{21^{k}} \cdot A(l) \cdot B(d) \le \frac{\text{LOD\_CAP}}{21^{k}} \cdot A(\text{white}) \cdot B(\text{black}) = \frac{\text{LOD\_CAP}}{21} < 1,$$
+$$\frac{c}{21^{k}} \cdot A(l) \cdot B(d) \le \frac{c}{21^{k}} \cdot A(\text{white}) \cdot B(\text{black}) = \frac{c}{21} < 1,$$
 
 hence $\text{OKCA} \le \text{WCAG}$, strictly.
 

--- a/docs/FP0_PROOF.md
+++ b/docs/FP0_PROOF.md
@@ -1,7 +1,7 @@
 # FP=0 — guaranteed by construction (issue #14)
 
-**Status: proven.** `OKCA ≤ WCAG` for every sRGB pair is now an **exact
-algebraic identity** plus **two single-colour lemmas verified by interval
+**Status: proven.** $\text{OKCA} \le \text{WCAG}$ for every sRGB pair is now an
+**exact algebraic identity** plus **two single-colour lemmas verified by interval
 arithmetic** — no calibration-dependent headroom, no residual. Reproduce:
 `npm run fp0` (certifies with **0 uncertified boxes**).
 
@@ -9,58 +9,72 @@ Constants: `POL_K` = 1.100, `CHROMA_K` = 0.65, `LOD_CAP` = 20.9, `DOL_CAP` = 20.
 
 ## 1. Algebraic reduction
 
-The final score is `OKCA = CAP·(raw/21)^k` with `raw = (lY+0.05)/(dY+0.05)`,
-`lY = (L_light^exp)^3` the chroma-penalised lighter proxy, `dY = L_dark^3`,
-`k = POL_K`, and `CAP = LOD_CAP` (light-on-dark) or `DOL_CAP` (dark-on-light).
-WCAG is `(Y_l+0.05)/(Y_d+0.05)`. Rearranging separates the two elements:
+The final score is
 
-```
-OKCA ≤ WCAG   ⇔   (CAP / 21^k) · A(lighter) · B(darker) ≤ 1
-  A(l) = (lY_l + 0.05)^k / (Y_l + 0.05)      (lighter element only)
-  B(d) = (Y_d + 0.05)   / (dY_d + 0.05)^k    (darker element only)
-```
+$$\text{OKCA} = \text{CAP} \cdot \left(\frac{r_{\text{raw}}}{21}\right)^{k}, \qquad r_{\text{raw}} = \frac{Y_{\text{lighter}} + 0.05}{Y_{\text{darker}} + 0.05},$$
+
+where $Y_{\text{lighter}} = \left(L_{\text{lighter}}^{\text{exp}}\right)^{3}$ is
+the chroma-penalised lighter proxy, $Y_{\text{darker}} = L_{\text{darker}}^{3}$,
+$k =$ `POL_K`, and $\text{CAP} =$ `LOD_CAP` (light-on-dark) or `DOL_CAP`
+(dark-on-light). Writing $Y_l$ and $Y_d$ for the **WCAG** luminances of the
+lighter and darker elements,
+
+$$r_{\text{WCAG}} = \frac{Y_l + 0.05}{Y_d + 0.05}.$$
+
+Rearranging separates the two elements:
+
+$$\text{OKCA} \le \text{WCAG} \iff \frac{\text{CAP}}{21^{k}} \cdot A(l) \cdot B(d) \le 1,$$
+
+$$A(l) = \frac{\left(Y_{\text{lighter}} + 0.05\right)^{k}}{Y_l + 0.05}, \qquad B(d) = \frac{Y_d + 0.05}{\left(Y_{\text{darker}} + 0.05\right)^{k}},$$
+
+where $A$ depends on the **lighter element only** and $B$ on the **darker element
+only**.
 
 ## 2. The exact identity
 
-At the achromatic anchors, for **any** k:
+At the achromatic anchors, for **any** $k$:
 
-```
-21^(1−k) · A(white) · B(black)
-  = 21^(1−k) · 1.05^(k−1) · 0.05^(1−k)
-  = (21·0.05)^(1−k) · 1.05^(k−1) = 1.05^(1−k) · 1.05^(k−1) = 1     (21·0.05 = 1.05)
-```
+$$\begin{aligned}
+21^{1-k} \cdot A(\text{white}) \cdot B(\text{black})
+  &= 21^{1-k} \cdot 1.05^{k-1} \cdot 0.05^{1-k} \\
+  &= (21 \cdot 0.05)^{1-k} \cdot 1.05^{k-1} \\
+  &= 1.05^{1-k} \cdot 1.05^{k-1} = 1,
+\end{aligned}$$
 
-(Verified to 1e-12 by `npm run fp0`.) `A` is maximised over sRGB at white,
-`B` at black — confirmed by a full-gamut search: `max A = A(white)`,
-`max B = B(black)`.
+since $21 \cdot 0.05 = 1.05$.
+
+(Verified to $10^{-12}$ by `npm run fp0`.) $A$ is maximised over sRGB at white,
+$B$ at black — confirmed by a full-gamut search: $\max A = A(\text{white})$,
+$\max B = B(\text{black})$.
 
 ## 3. The lowered cap removes the equality
 
-With `CAP = 21` the bound at the anchor is `21/21 = 1` — **tight**, so white-on-
-black would be the single point where `OKCA = WCAG`, which interval arithmetic
-cannot certify (it cannot prove a non-strict equality). Setting **`LOD_CAP =
-20.9 < 21`** makes the anchor bound
+With $\text{CAP} = 21$ the bound at the anchor is $21/21 = 1$ — **tight**, so
+white-on-black would be the single point where $\text{OKCA} = \text{WCAG}$, which
+interval arithmetic cannot certify (it cannot prove a non-strict equality).
+Setting **`LOD_CAP` $= 20.9 < 21$** makes the anchor bound
 
-```
-(LOD_CAP / 21^k) · A(white) · B(black) = LOD_CAP / 21 = 0.99524 < 1,
-```
+$$\frac{\text{LOD\_CAP}}{21^{k}} \cdot A(\text{white}) \cdot B(\text{black}) = \frac{\text{LOD\_CAP}}{21} = 0.99524 < 1,$$
 
 a **uniform strict margin**. There is now no equality point anywhere: OKCA is
-*strictly* below WCAG for every sRGB pair. (Dark-on-light, `CAP = 20`, is looser
-still.) The `20.9/21` factor is the deliberate, minimal step that converts the
-guarantee from "gamut-verified headroom" to "strict by construction".
+*strictly* below WCAG for every sRGB pair. (Dark-on-light, $\text{CAP} = 20$, is
+looser still.) The $20.9/21$ factor is the deliberate, minimal step that converts
+the guarantee from "gamut-verified headroom" to "strict by construction".
 
 ## 4. Reduction to two verified lemmas
 
-`A ≥ 0`, `B ≥ 0`, and the identity give: the pair inequality follows from
+$A \ge 0$, $B \ge 0$, and the identity give: the pair inequality follows from
 
-```
-(L-A)  A(l) ≤ A(white)·s        for all sRGB l
-(L-B)  B(d) ≤ B(black)·s        for all sRGB d,     s = √(21 / LOD_CAP) = 1.00239
-```
+$$\begin{aligned}
+\text{(L-A)} \quad & A(l) \le A(\text{white}) \cdot s && \text{for all sRGB } l, \\
+\text{(L-B)} \quad & B(d) \le B(\text{black}) \cdot s && \text{for all sRGB } d,
+\end{aligned}$$
 
-since then `(LOD_CAP/21^k)·A·B ≤ (LOD_CAP/21^k)·A(white)·B(black)·s² =
-LOD_CAP/21 · (21/LOD_CAP) = 1`. `scripts/fp0-proof.ts` branch-and-bounds each
+with $s = \sqrt{21 / \text{LOD\_CAP}} = 1.00239$, since then
+
+$$\frac{\text{LOD\_CAP}}{21^{k}} \cdot A \cdot B \le \frac{\text{LOD\_CAP}}{21^{k}} \cdot A(\text{white}) \cdot B(\text{black}) \cdot s^{2} = \frac{\text{LOD\_CAP}}{21} \cdot \frac{21}{\text{LOD\_CAP}} = 1.$$
+
+`scripts/fp0-proof.ts` branch-and-bounds each
 lemma over the sRGB cube with sound outward-rounded interval arithmetic
 (`scripts/interval.ts`, exact Ottosson OKLab matrices + the WCAG luminance
 formula; enclosures validated to contain production values). A box is certified
@@ -71,20 +85,19 @@ Result (`npm run fp0`):
 
 | lemma | boxes | certified | equality corners | **uncertified** |
 |-------|------:|----------:|-----------------:|----------------:|
-| A(l) ≤ A(white)·s | ~96k | all | 0 | **0** |
-| B(d) ≤ B(black)·s | ~272k | all | 0 | **0** |
+| $A(l) \le A(\text{white}) \cdot s$ | ~96k | all | 0 | **0** |
+| $B(d) \le B(\text{black}) \cdot s$ | ~272k | all | 0 | **0** |
 
-Every sRGB point is certified; the slack `s > 1` from the lowered cap lets even
+Every sRGB point is certified; the slack $s > 1$ from the lowered cap lets even
 the anchors certify, so no neighbourhood is excluded.
 
 ## 5. Conclusion
 
 For every ordered sRGB pair:
 
-```
-(LOD_CAP / 21^k) · A(l) · B(d) ≤ (LOD_CAP / 21^k) · A(white) · B(black) = LOD_CAP/21 < 1
-⇒ OKCA ≤ WCAG,  strictly.
-```
+$$\frac{\text{LOD\_CAP}}{21^{k}} \cdot A(l) \cdot B(d) \le \frac{\text{LOD\_CAP}}{21^{k}} \cdot A(\text{white}) \cdot B(\text{black}) = \frac{\text{LOD\_CAP}}{21} < 1,$$
+
+hence $\text{OKCA} \le \text{WCAG}$, strictly.
 
 **FP = 0 is guaranteed by construction across the full sRGB gamut** — the
 chromatic case (issue #14's gap) is closed. The argument depends only on the

--- a/docs/GAMUT_SWEEP_FINDINGS.md
+++ b/docs/GAMUT_SWEEP_FINDINGS.md
@@ -35,7 +35,7 @@ WCAG values use the standard relative-luminance formula, reimplemented inline
 OKCA's darker-element luminance proxy is $L^3$ (OKLCH lightness cubed). WCAG
 uses relative luminance
 
-$$Y = 0.2126\,R_{\text{lin}} + 0.7152\,G_{\text{lin}} + 0.0722\,B_{\text{lin}}$$
+$$Y = 0.2126\thinspace R_{\text{lin}} + 0.7152\thinspace G_{\text{lin}} + 0.0722\thinspace B_{\text{lin}}$$
 
 (linearised sRGB). Their gap
 
@@ -121,7 +121,7 @@ conservatism is a **vivid-colour** phenomenon; pastels barely diverge:
 **Key consequence:** at *matched* chroma ($C \approx 0.17$) the divergence is
 green $-0.025$, blue $+0.004$, magenta $+0.020$ — **opposite signs at equal
 chroma.** No function of chroma magnitude alone ($C = \sqrt{a^2 + b^2}$) can
-flatten it; only the *direction* of $a$/$b$ (i.e. hue) distinguishes green from
+flatten it; only the *direction* of $a$ and $b$ (i.e. hue) distinguishes green from
 magenta.
 
 ---
@@ -244,9 +244,9 @@ perceptual contrast metric in its own right. Sketch of what that could be
 
 1. **Effective perceptual lightness** that folds the Helmholtz–Kohlrausch effect
    (saturated colours appear brighter than their luminance) into lightness as a
-   *smooth function of $(a, b)$* — no hue angle, no hue bands. Freed from
+   *smooth function of* $(a, b)$ — no hue angle, no hue bands. Freed from
    matching $Y$, this chroma term becomes a legitimate appearance model rather
-   than a "$Y$ in disguise" correction:
+   than a "Y in disguise" correction:
    $\text{Ł} = L + f(a, b)$, with $f$ smooth and $\approx 0$ at $a = b = 0$.
 2. **Polarity-native, difference-based contrast** on $\text{Ł}$ (signed by direction,
    with distinct exponents per polarity and a soft clamp near black) instead of a

--- a/docs/GAMUT_SWEEP_FINDINGS.md
+++ b/docs/GAMUT_SWEEP_FINDINGS.md
@@ -9,10 +9,10 @@ OKLCH hue and chroma. This is *analysis* — running it changed no algorithm cod
 > `DOL_CAP = 20`, `C_THRESH = 0.15`. Two kinds of finding live here, and they
 > age differently:
 >
-> - **Structural (constant-independent):** the `δ = L³ − Y` divergence in
->   §0–§2. It depends only on OKCA's luminance proxy (`L³`) versus WCAG
+> - **Structural (constant-independent):** the $\delta = L^3 - Y$ divergence in
+>   §0–§2. It depends only on OKCA's luminance proxy ($L^3$) versus WCAG
 >   luminance — **not** on the scaling constants — so it is stable across any
->   recalibration that keeps the `L³` proxy.
+>   recalibration that keeps the $L^3$ proxy.
 > - **Calibration-dependent:** the conservatism/slack, disagreement counts, and
 >   FP-margin figures in §3–§4. These shift if the constants change (e.g.
 >   lowering `LOD_CAP` widened the green FP margin from 0.2 to 0.3). **Re-run
@@ -32,20 +32,24 @@ WCAG values use the standard relative-luminance formula, reimplemented inline
 
 ## 0. The core quantity: δ = L³ − Y
 
-OKCA's darker-element luminance proxy is **L³** (OKLCH lightness cubed). WCAG
-uses **relative luminance Y** = `0.2126 R + 0.7152 G + 0.0722 B` (linearised).
-Their gap
+OKCA's darker-element luminance proxy is $L^3$ (OKLCH lightness cubed). WCAG
+uses relative luminance
 
-> **δ = L³ − Y**
+$$Y = 0.2126\,R_{\text{lin}} + 0.7152\,G_{\text{lin}} + 0.0722\,B_{\text{lin}}$$
+
+(linearised sRGB). Their gap
+
+$$\delta = L^3 - Y$$
 
 is the single quantity behind every hue-specific effect below. Sign convention:
-`δ > 0` means OKCA's proxy reads a colour **lighter** than WCAG's luminance does
-(so, as a background, *less* contrast with white → OKCA scores it **stricter**);
-`δ < 0` means OKCA reads it **darker** → OKCA would score it **looser**.
+$\delta > 0$ means OKCA's proxy reads a colour **lighter** than WCAG's luminance
+does (so, as a background, *less* contrast with white → OKCA scores it
+**stricter**); $\delta < 0$ means OKCA reads it **darker** → OKCA would score it
+**looser**.
 
-**Achromatic validation.** Over greys (C < 0.02, n = 318): mean `|δ| = 0.0015`
-≈ 0. On the neutral axis `L³ = Y` by construction — *all* divergence is
-chromatic.
+**Achromatic validation.** Over greys ($C < 0.02$, $n = 318$): mean
+$|\delta| = 0.0015 \approx 0$. On the neutral axis $L^3 = Y$ by construction —
+*all* divergence is chromatic.
 
 ---
 
@@ -53,7 +57,7 @@ chromatic.
 
 (`npm run divergence`, sRGB grid step 8)
 
-| colour | hex | OKLCH L | L³ (OKCA) | Y (WCAG) | δ = L³−Y | L³/Y |
+| colour | hex | OKLCH $L$ | $L^3$ (OKCA) | $Y$ (WCAG) | $\delta = L^3 - Y$ | $L^3/Y$ |
 |--------|-----|--------:|----------:|---------:|---------:|-----:|
 | pure green   | `#00ff00` | 0.866 | 0.650 | 0.715 | **−0.065** | 0.91 |
 | pure cyan    | `#00ffff` | 0.905 | 0.742 | 0.787 | −0.045 | 0.94 |
@@ -67,19 +71,20 @@ chromatic.
 
 **Root cause.** WCAG's coefficients **under-weight blue** (0.0722) and
 **over-weight green** (0.7152) relative to perceptual OKLCH lightness. So WCAG
-treats pure blue as nearly black (Y = 0.072) and green as bright (Y = 0.715);
-OKCA's perceptual lightness disagrees in both directions. Note pure blue has the
-largest *ratio* (L³/Y = 1.28) because Y is tiny, while magenta has the largest
-*absolute* δ (+0.061).
+treats pure blue as nearly black ($Y = 0.072$) and green as bright
+($Y = 0.715$); OKCA's perceptual lightness disagrees in both directions. Note
+pure blue has the largest *ratio* ($L^3/Y = 1.28$) because $Y$ is tiny, while
+magenta has the largest *absolute* $\delta$ ($+0.061$).
 
 ---
 
 ## 2. Divergence by hue (the hue-specific deltas)
 
-Mean δ over saturated colours (C ≥ 0.10), 30° OKLCH hue bins, and the implied
-white-on-colour raw bias `OKCA_raw / WCAG = (Y + 0.05)/(L³ + 0.05)`:
+Mean $\delta$ over saturated colours ($C \ge 0.10$), 30° OKLCH hue bins, and the
+implied white-on-colour raw bias
+$\text{OKCA}_{\text{raw}} / \text{WCAG} = (Y + 0.05)/(L^3 + 0.05)$:
 
-| hue | bin° | n | mean δ | OKCA_raw / WCAG | direction |
+| hue | bin° | $n$ | mean $\delta$ | $\text{OKCA}_{\text{raw}} / \text{WCAG}$ | direction |
 |-----|-----:|--:|-------:|----------------:|-----------|
 | red        |   0–30  | 2545 | +0.022 | 0.911 | stricter |
 | red-orange |  30–60  | 1628 | +0.018 | 0.937 | stricter |
@@ -94,13 +99,14 @@ white-on-colour raw bias `OKCA_raw / WCAG = (Y + 0.05)/(L³ + 0.05)`:
 | magenta    | 300–330 | 2975 | +0.026 | **0.899** | stricter (max) |
 | pink       | 330–360 | 2708 | +0.028 | 0.901 | stricter |
 
-**Two neutral hues** where δ ≈ 0 (**~yellow, 105°** and **~sky-blue, 225°**)
+**Two neutral hues** where $\delta \approx 0$ (**~yellow, 105°** and
+**~sky-blue, 225°**)
 split the wheel: a green/cyan lobe where OKCA runs up to **6% looser** than WCAG
 (raw), and a blue→magenta→red arc where OKCA runs up to **10% stricter**.
 
 ### δ scales with chroma
 
-δ is ≈ 0 for near-neutral colours and grows toward the primaries — the
+$\delta$ is $\approx 0$ for near-neutral colours and grows toward the primaries — the
 conservatism is a **vivid-colour** phenomenon; pastels barely diverge:
 
 | chroma band | GREEN (120–150°) | BLUE (240–270°) | MAGENTA (300–330°) |
@@ -112,19 +118,21 @@ conservatism is a **vivid-colour** phenomenon; pastels barely diverge:
 | 0.15–0.20 | −0.025 | +0.004 | +0.020 |
 | 0.20–0.40 | −0.044 | +0.013 | +0.033 |
 
-**Key consequence:** at *matched* chroma (C ≈ 0.17) the divergence is green
-−0.025, blue +0.004, magenta +0.020 — **opposite signs at equal chroma.** No
-function of chroma magnitude alone (`C = √(a²+b²)`) can flatten it; only the
-*direction* of `a`/`b` (i.e. hue) distinguishes green from magenta.
+**Key consequence:** at *matched* chroma ($C \approx 0.17$) the divergence is
+green $-0.025$, blue $+0.004$, magenta $+0.020$ — **opposite signs at equal
+chroma.** No function of chroma magnitude alone ($C = \sqrt{a^2 + b^2}$) can
+flatten it; only the *direction* of $a$/$b$ (i.e. hue) distinguishes green from
+magenta.
 
 ---
 
 ## 3. Conservatism by hue (chromatic colours vs white)
 
-(`npm run hue`, sRGB grid step 12) — mean WCAG − OKCA slack, and count of
-disagreement-zone pairs (OKCA < 4.5 while WCAG ≥ 4.5):
+(`npm run hue`, sRGB grid step 12) — mean $\text{WCAG} - \text{OKCA}$ slack, and
+count of disagreement-zone pairs ($\text{OKCA} < 4.5$ while
+$\text{WCAG} \ge 4.5$):
 
-| hue | bin° | n | mean slack (L-o-D) | mean slack (D-o-L) | disagreements (LoD / DoL) |
+| hue | bin° | $n$ | mean slack (L-o-D) | mean slack (D-o-L) | disagreements (LoD / DoL) |
 |-----|-----:|--:|-------------------:|-------------------:|--------------------------:|
 | red        |   0–30  |  981 | 1.06 | 1.26 | 174 / 200 |
 | red-orange |  30–60  |  679 | 0.86 | 1.04 |  82 / 88 |
@@ -142,19 +150,19 @@ disagreement-zone pairs (OKCA < 4.5 while WCAG ≥ 4.5):
 OKCA is most conservative on the **purple / magenta / pink / red / blue** arc
 (~1.0–1.2 points below WCAG) and least on **green / teal / cyan** (~0.38). The
 disagreement zone — false failures — concentrates almost entirely in the former.
-The per-hue slack ranks **identically** to the per-hue raw bias in §2, so δ is
-the *mechanism*, not merely a correlate. D-o-L slack runs ~0.2 above L-o-D
+The per-hue slack ranks **identically** to the per-hue raw bias in §2, so
+$\delta$ is the *mechanism*, not merely a correlate. D-o-L slack runs ~0.2 above L-o-D
 (the polarity penalty).
 
 ---
 
 ## 4. FP=0 headroom by hue (the "green wall")
 
-Tightest WCAG − OKCA margin when each hue is the **darker** element under
+Tightest $\text{WCAG} - \text{OKCA}$ margin when each hue is the **darker** element under
 light-chromatic foregrounds (the overshoot-risk configuration). FP = 0 holds
 everywhere — 0 false passes across ~14M pairs:
 
-| darker-element hue | bin° | pairs | min WCAG−OKCA margin | tightest pair |
+| darker-element hue | bin° | pairs | min $\text{WCAG} - \text{OKCA}$ margin | tightest pair |
 |--------------------|-----:|------:|---------------------:|---------------|
 | green      | 120–150 | 1,114,112 | **0.3** | `#ffffd8` on `#002400` (OKCA 16.1 / WCAG 16.4) |
 | green-teal | 150–180 |   491,776 | **0.3** | `#fcffd8` on `#00240c` (OKCA 15.9 / WCAG 16.2) |
@@ -178,7 +186,7 @@ widened it — the same headroom that made FP=0 provable in `docs/FP0_PROOF.md`.
 
 ## 5. Synthesis
 
-Findings §2–§4 are one fact viewed three ways. Because `L³` **undershoots** Y
+Findings §2–§4 are one fact viewed three ways. Because $L^3$ **undershoots** $Y$
 for green and **overshoots** for blue/purple:
 
 - **Green / cyan** land ≈ WCAG → least conservative (small slack) **and**
@@ -188,11 +196,11 @@ for green and **overshoots** for blue/purple:
 
 ### Two mechanistically distinct sources of OKCA's conservatism
 
-1. **Achromatic compression** (`POL_K` / the anchor). δ = 0 on the grey axis, so
+1. **Achromatic compression** (`POL_K` / the anchor). $\delta = 0$ on the grey axis, so
    the grey-500 / neutral over-conservatism is *pure calibration*, unrelated to
    luminance divergence. This is the legitimately tunable part (and what the
    white/#767676 → 3.9 anchor move targeted).
-2. **Chromatic divergence** (δ). The blue/purple/magenta strictness is a
+2. **Chromatic divergence** ($\delta$). The blue/purple/magenta strictness is a
    *principled* correction of WCAG's blue-underweighting — arguably the most
    defensible part of OKCA's conservatism, not an error.
 
@@ -200,17 +208,18 @@ A global `POL_K` lever conflates the two: it relieves (1) but also erodes (2).
 
 ### OKCA is a one-sided detector of WCAG's luminance weakness
 
-FP = 0 forces `OKCA ≤ WCAG` for every pair. So OKCA can only ever express
-WCAG's **over-rating** (blue/purple/saturated, where δ > 0 makes OKCA stricter).
-Where OKCA's own proxy says WCAG is **too harsh** (green, δ < 0, OKCA would score
+FP = 0 forces $\text{OKCA} \le \text{WCAG}$ for every pair. So OKCA can only ever
+express WCAG's **over-rating** (blue/purple/saturated, where $\delta > 0$ makes
+OKCA stricter). Where OKCA's own proxy says WCAG is **too harsh** (green,
+$\delta < 0$, OKCA would score
 *higher* than WCAG), FP = 0 clamps it — that signal is structurally hidden. The
 tight (0.3) green FP margin is OKCA straining against its own leash. **OKCA
 surfaces half of WCAG's hue-luminance weakness by design.**
 
 ### Important limit
 
-Calling δ a "weakness of WCAG" is a perceptual value judgement OKCA *supports*
-but does not *prove*: `L³` is itself a proxy, not validated legibility ground
+Calling $\delta$ a "weakness of WCAG" is a perceptual value judgement OKCA
+*supports* but does not *prove*: $L^3$ is itself a proxy, not validated legibility ground
 truth. What the sweep establishes rigorously is that the divergence is real,
 hue-systematic, chroma-scaled, and centred on WCAG's known luminance blind spot.
 Which model is *correct* needs empirical legibility data OKCA does not have.
@@ -222,10 +231,10 @@ Which model is *correct* needs empirical legibility data OKCA does not have.
 The properties above are limited by tethers OKCA inherits from WCAG 2, not by
 its OKLCH foundation:
 
-- **FP = 0 (`OKCA ≤ WCAG`)** — the ceiling that makes OKCA one-sided.
-- **`L³` calibrated to equal Y on the grey axis** — makes the chroma term an
-  approximation of Y rather than a free perceptual model.
-- **The 1–21 luminance-ratio scale** with the `+0.05` flare term.
+- **FP = 0 ($\text{OKCA} \le \text{WCAG}$)** — the ceiling that makes OKCA one-sided.
+- **$L^3$ calibrated to equal $Y$ on the grey axis** — makes the chroma term an
+  approximation of $Y$ rather than a free perceptual model.
+- **The 1–21 luminance-ratio scale** with the $+0.05$ flare term.
 - **Single size-independent AA/AAA thresholds.**
 - **Polarity bolted on** as a cap (`DOL_CAP`) atop a symmetric ratio.
 
@@ -235,11 +244,11 @@ perceptual contrast metric in its own right. Sketch of what that could be
 
 1. **Effective perceptual lightness** that folds the Helmholtz–Kohlrausch effect
    (saturated colours appear brighter than their luminance) into lightness as a
-   *smooth function of `(a, b)`* — no hue angle, no hue bands. Freed from
-   matching Y, this chroma term becomes a legitimate appearance model rather than
-   a "Y in disguise" correction:
-   `Ł = L + f(a, b)`, with `f` smooth and ≈ 0 at `a = b = 0`.
-2. **Polarity-native, difference-based contrast** on `Ł` (signed by direction,
+   *smooth function of $(a, b)$* — no hue angle, no hue bands. Freed from
+   matching $Y$, this chroma term becomes a legitimate appearance model rather
+   than a "$Y$ in disguise" correction:
+   $\text{Ł} = L + f(a, b)$, with $f$ smooth and $\approx 0$ at $a = b = 0$.
+2. **Polarity-native, difference-based contrast** on $\text{Ł}$ (signed by direction,
    with distinct exponents per polarity and a soft clamp near black) instead of a
    luminance ratio.
 3. **Usability thresholds decoupled from the metric** — a lookup on
@@ -265,5 +274,5 @@ gamut before such data exists.
 | script | npm | produces |
 |--------|-----|----------|
 | `scripts/hue-analysis.ts` | `npm run hue` | §3 conservatism-by-hue, §4 FP-margin-by-hue |
-| `scripts/divergence-analysis.ts` | `npm run divergence` | §0–§2 δ = L³ − Y landmarks, by-hue, chroma scaling |
+| `scripts/divergence-analysis.ts` | `npm run divergence` | §0–§2 $\delta = L^3 - Y$ landmarks, by-hue, chroma scaling |
 | `scripts/calibration-sweep.ts` | `npm run calibrate` | full-gamut FP=0 verification |

--- a/docs/OKCA_DESIGN.md
+++ b/docs/OKCA_DESIGN.md
@@ -75,7 +75,7 @@ When the algorithm must choose between overcounting contrast (false pass) and un
 
 WCAG luminance is defined as:
 
-$$Y = 0.2126\,R_{\text{lin}} + 0.7152\,G_{\text{lin}} + 0.0722\,B_{\text{lin}}$$
+$$Y = 0.2126\thinspace R_{\text{lin}} + 0.7152\thinspace G_{\text{lin}} + 0.0722\thinspace B_{\text{lin}}$$
 
 per IEC 61966-2-1 (linearised sRGB). This formula was designed for display calibration, not for predicting legibility. Two shortcomings are relevant to OKCA:
 
@@ -115,15 +115,17 @@ overshoot. When the **darker** element is chromatic — especially green — its
 proxy can fall below $Y_{\text{WCAG}}$, shrinking the denominator and pushing the
 **raw** ratio *above* the WCAG ratio. So, for chromatic darker elements:
 
-$$r_{\text{raw}} = \frac{Y_{\text{lighter}} + 0.05}{Y_{\text{darker}} + 0.05} \;\not\le\; r_{\text{WCAG}} \quad\text{in general.}$$
+$$r_{\text{raw}} = \frac{Y_{\text{lighter}} + 0.05}{Y_{\text{darker}} + 0.05} \quad \not\le \quad r_{\text{WCAG}} \quad\text{in general.}$$
 
-This is the step where a naive "$L^3 = Y_{\text{WCAG}}$, therefore $r_{\text{raw}} \le r_{\text{WCAG}}$" argument fails. FP = 0 is **not** carried by the raw ratio.
+This is the step where the naive argument — $L^3 = Y_{\text{WCAG}}$, therefore $r_{\text{raw}} \le r_{\text{WCAG}}$ — fails. FP = 0 is **not** carried by the raw ratio.
 
 ### Step 5: the polarity curve supplies the margin (by construction)
 
 The final ratio is
 
-$$\text{ratio} = \text{CAP} \times \left(\frac{r_{\text{raw}}}{21}\right)^{k}, \qquad k = \text{POL\_K} = 1.100 \ge 1, \quad \text{CAP} \le \text{LOD\_CAP} = 20.9 < 21.$$
+$$\text{ratio} = \text{CAP} \times \left(\frac{r_{\text{raw}}}{21}\right)^{k}, \qquad k = 1.100 \ge 1, \quad \text{CAP} \le 20.9 < 21.$$
+
+where $k$ is `POL_K` and the cap ceiling is `LOD_CAP` = 20.9.
 
 Rewriting, $\text{ratio} = r_{\text{raw}} \times (r_{\text{raw}}/21)^{k-1} \times (\text{CAP}/21)$. Since $k \ge 1$ and $r_{\text{raw}} \le 21$, the factor $(r_{\text{raw}}/21)^{k-1} \le 1$; and $\text{CAP}/21 < 1$ (strictly, since $\text{CAP} \le 20.9$). Therefore, **unconditionally**:
 
@@ -148,7 +150,7 @@ $$21^{1-k} \cdot A(\text{white}) \cdot B(\text{black}) = (21\cdot 0.05)^{1-k}\cd
 
 exactly (since $21\cdot 0.05 = 1.05$). Because the L-o-D cap is set **below 21**
 (`LOD_CAP` = 20.9), the bound at the anchor becomes
-$\text{LOD\_CAP}/21 = 0.99524 < 1$ — a strict margin, so there is **no equality
+$20.9/21 = 0.99524 < 1$ — a strict margin, so there is **no equality
 point** and OKCA is strictly below WCAG everywhere. FP = 0 then reduces to two single-colour lemmas,
 $A(l) \le A(\text{white})$ and $B(d) \le B(\text{black})$, each **verified by
 interval arithmetic** over the sRGB cube with **0 uncertified boxes**
@@ -177,7 +179,7 @@ Because WCAG contrast is a function of $Y$ alone, any two foreground colors shar
 | Foreground | $Y$ | WCAG on `#1a1a1a` | OKCA on `#1a1a1a` |
 |---|---:|---:|---:|
 | `#ff69b4` (hot pink) | 0.347 | 6.6 | 3.6 |
-| `#9f9f9f` (same-$Y$ grey) | 0.347 | 6.6 | 5.8 |
+| `#9f9f9f` (grey at the same $Y$) | 0.347 | 6.6 | 5.8 |
 
 WCAG scores them identically. OKCA scores hot pink 3.6 (fails AA) and the grey 5.8 (passes AA).
 
@@ -231,9 +233,12 @@ $$\text{ratio} = \text{CAP} \times \left(\frac{r}{21}\right)^{k}$$
 
 where $k =$ `POL_K` $= 1.100$ and:
 
-$$\text{CAP} = \begin{cases} 20.9 & \text{if text is lighter (light-on-dark)} \\ 20 & \text{if background is lighter (dark-on-light)} \end{cases}$$
+$$\text{CAP} = \begin{cases}
+20.9 & \text{if text is lighter (light-on-dark)} \\
+20 & \text{if background is lighter (dark-on-light)}
+\end{cases}$$
 
-For L-o-D ($\text{CAP} = \text{LOD\_CAP} = 20.9$): the formula pins at 20.9 when $r = 21$ — a hair below WCAG's 21, the strict-margin that makes FP = 0 hold by construction (Section 4) — and reduces all lower ratios by the power factor. For D-o-L ($\text{CAP} = 20$): the same power curve with a lower cap, applying a polarity penalty at every contrast level. Both polarities share the same exponent $k$, giving consistent curve shape.
+For L-o-D (`LOD_CAP`, $\text{CAP} = 20.9$): the formula pins at 20.9 when $r = 21$ — a hair below WCAG's 21, the strict-margin that makes FP = 0 hold by construction (Section 4) — and reduces all lower ratios by the power factor. For D-o-L ($\text{CAP} = 20$): the same power curve with a lower cap, applying a polarity penalty at every contrast level. Both polarities share the same exponent $k$, giving consistent curve shape.
 
 **Rationale.** Designers and design systems treat polarity as a meaningful input --- dark mode and light mode are distinct design decisions, and practitioners evaluate them differently. WCAG's symmetric formula discards this information. OKCA encodes the asymmetry as a calibrated design choice: a light-on-dark pair scores higher than the same colours reversed, anchored to practitioner-accepted reference values (white/black = 20.9/20.0, `#767676` = 3.9/3.7). Both transforms produce ratios strictly at or below the raw WCAG value (all scores are conservative).
 
@@ -282,9 +287,9 @@ By system: Tailwind CSS v3.4 (34), GOV.UK Design System (13), USWDS v3.x (50). S
 
 - **`POL_K` = 1.100** --- Calibrated so white/`#767676` (WCAG AA boundary grey) scores 3.9 under L-o-D (raised from a 3.5 anchor / `POL_K` 1.175 to reduce over-conservatism on mid-range chromatics). Derived: $k = \ln(3.9/21) / \ln(4.54/21) \approx 1.0996$.
 
-- **`LOD_CAP` = 20.9** --- Light-on-dark cap, one notch below 21. This is the strict-margin lever for the FP=0 proof: with the cap below 21 the identity $21^{1-k} \cdot A(\text{white}) \cdot B(\text{black}) = 1$ becomes $\text{LOD\_CAP}/21 = 0.99524 < 1$, removing the single white-on-black equality point so OKCA is strictly below WCAG everywhere (Section 4). White on black: 20.9.
+- **`LOD_CAP` = 20.9** --- Light-on-dark cap, one notch below 21. This is the strict-margin lever for the FP=0 proof: with the cap below 21 the identity $21^{1-k} \cdot A(\text{white}) \cdot B(\text{black}) = 1$ becomes $20.9/21 = 0.99524 < 1$, removing the single white-on-black equality point so OKCA is strictly below WCAG everywhere (Section 4). White on black: 20.9.
 
-- **`DOL_CAP` = 20** --- Proportional polarity penalty for D-o-L: at any given raw ratio, D-o-L scores $(20/20.9) \approx 96\%$ of the equivalent L-o-D score. Black on white: 20.0. `#767676` on white: $(20/20.9) \times 3.9 \approx 3.7$.
+- **`DOL_CAP` = 20** --- Proportional polarity penalty for D-o-L: at any given raw ratio, D-o-L scores $20/20.9 \approx 0.96$ — about 96% — of the equivalent L-o-D score. Black on white: 20.0. `#767676` on white: $(20/20.9) \times 3.9 \approx 3.7$.
 
 ---
 

--- a/docs/OKCA_DESIGN.md
+++ b/docs/OKCA_DESIGN.md
@@ -29,7 +29,7 @@ OKCA processes a foreground/background color pair in five steps:
 2. **Identify polarity.** The element with higher L is the lighter element. If the foreground is lighter the pair is light-on-dark (L-o-D); if the background is lighter it is dark-on-light (D-o-L).
 3. **Compress the lighter element.** Compute Oklab chroma $C = \sqrt{a^2+b^2}$. Apply a chroma-weighted power exponent to the lighter element's L, reducing its effective luminance proxy. Higher chroma → larger reduction.
 4. **Compute the darker element's proxy.** The darker element uses $L^3$ directly — no chroma correction applied.
-5. **Apply polarity-aware scaling.** Form a raw ratio from the two luminance proxies, then scale with a power curve that differs by polarity: L-o-D uses a cap of 20.9 (`LOD_CAP`); D-o-L uses 20. Output is in [1, 21].
+5. **Apply polarity-aware scaling.** Form a raw ratio from the two luminance proxies, then scale with a power curve that differs by polarity: L-o-D uses a cap of 20.9 (`LOD_CAP`); D-o-L uses 20. Output is in $[1, 21]$.
 
 Sections 3–7 cover each step in depth. Section 4 establishes FP = 0 — by construction on the achromatic axis, and by gamut-wide verification for chromatic inputs.
 
@@ -43,7 +43,7 @@ A contrast algorithm used for accessibility decisions must never approve a pair 
 
 ### 2.2 WCAG-Compatible Scale and Thresholds
 
-OKCA outputs ratios in [1, 21], uses the same AA threshold (4.5) and AAA threshold (7.0) as WCAG 2.x. Designers and developers see familiar numbers. No re-education required.
+OKCA outputs ratios in $[1, 21]$, uses the same AA threshold (4.5) and AAA threshold (7.0) as WCAG 2.x. Designers and developers see familiar numbers. No re-education required.
 
 ### 2.3 OKLCH L as the Luminance Input
 
@@ -136,7 +136,7 @@ ratio by a margin that grows as the ratio falls below 21.
 
 The raw ratio can exceed WCAG for chromatic darker elements, so FP = 0 is **not**
 carried by the raw ratio. But the full inequality **is** a theorem. Rearranging
-`OKCA ≤ WCAG` separates the two elements completely:
+$\text{OKCA} \le \text{WCAG}$ separates the two elements completely:
 
 $$\text{OKCA} \le \text{WCAG} \iff \frac{\text{CAP}}{21^{k}} \cdot A(\text{lighter}) \cdot B(\text{darker}) \le 1,$$
 
@@ -147,9 +147,9 @@ element. At the achromatic anchors, for any $k$,
 $$21^{1-k} \cdot A(\text{white}) \cdot B(\text{black}) = (21\cdot 0.05)^{1-k}\cdot 1.05^{k-1} = 1$$
 
 exactly (since $21\cdot 0.05 = 1.05$). Because the L-o-D cap is set **below 21**
-(`LOD_CAP` = 20.9), the bound at the anchor becomes $\text{LOD\_CAP}/21 =
-0.99524 < 1$ — a strict margin, so there is **no equality point** and OKCA is
-strictly below WCAG everywhere. FP = 0 then reduces to two single-colour lemmas,
+(`LOD_CAP` = 20.9), the bound at the anchor becomes
+$\text{LOD\_CAP}/21 = 0.99524 < 1$ — a strict margin, so there is **no equality
+point** and OKCA is strictly below WCAG everywhere. FP = 0 then reduces to two single-colour lemmas,
 $A(l) \le A(\text{white})$ and $B(d) \le B(\text{black})$, each **verified by
 interval arithmetic** over the sRGB cube with **0 uncertified boxes**
 (`npm run fp0`; full argument in [`docs/FP0_PROOF.md`](FP0_PROOF.md)).
@@ -193,11 +193,11 @@ ranging from 1.0 (achromatic) to 1.65 (fully saturated). The adjusted luminance 
 
 $$Y_{\text{lighter}} = \left(L_{\text{lighter}}^{\text{exp}}\right)^3$$
 
-For a neutral white lighter element: C = 0, satW = 0, exp = 1, so $Y_{\text{lighter}} = L^3 = 1.0$ --- unchanged.
+For a neutral white lighter element: $C = 0$, $\text{satW} = 0$, $\text{exp} = 1$, so $Y_{\text{lighter}} = L^3 = 1.0$ --- unchanged.
 
-For hot pink (C ≈ 0.197 > 0.15): satW = 1, exp = 1.65 --- the lighter element is penalised. After Step 5 polarity scaling, hot pink/near-black drops to 3.6, below the 4.5 AA threshold.
+For hot pink ($C \approx 0.197 > 0.15$): $\text{satW} = 1$, $\text{exp} = 1.65$ --- the lighter element is penalised. After Step 5 polarity scaling, hot pink/near-black drops to 3.6, below the 4.5 AA threshold.
 
-The threshold of 0.15 is calibrated so the penalty is negligible for lightly tinted neutrals (e.g. off-white at C ≈ 0.01) and fully active for vivid designer palette colours (C ≥ 0.15).
+The threshold of 0.15 is calibrated so the penalty is negligible for lightly tinted neutrals (e.g. off-white at $C \approx 0.01$) and fully active for vivid designer palette colours ($C \ge 0.15$).
 
 ---
 
@@ -205,7 +205,7 @@ The threshold of 0.15 is calibrated so the penalty is negligible for lightly tin
 
 For neutral grey pairs, chroma compression reduces to identity:
 
-- **Step 3:** Oklab chroma C = 0, so satW = 0, exp = 1, and $Y_{\text{lighter}} = L^3$.
+- **Step 3:** Oklab chroma $C = 0$, so $\text{satW} = 0$, $\text{exp} = 1$, and $Y_{\text{lighter}} = L^3$.
 - **Step 4:** $Y_{\text{darker}} = L^3$ (no correction applied).
 
 Since $L^3 \approx Y_{\text{WCAG}}$ for greys (up to floating-point precision of the OKLCH transform), the raw contrast ratio before Step 5 equals the WCAG ratio for neutral pairs. The polarity power model (Step 5) then scales scores according to polarity. The achromatic anchors are:
@@ -270,19 +270,19 @@ By system: Tailwind CSS v3.4 (34), GOV.UK Design System (13), USWDS v3.x (50). S
 |----------|------:|------|
 | `C_THRESH` | 0.15 | Oklab chroma at which lighter-element penalty is fully active |
 | `CHROMA_K` | 0.65 | Maximum additional power exponent at full saturation (exp range: 1.0–1.65) |
-| `POL_K` | 1.100 | Shared polarity power exponent: CAP×(r/21)^k |
+| `POL_K` | 1.100 | Shared polarity power exponent: $\text{CAP} \times (r/21)^{k}$ |
 | `LOD_CAP` | 20.9 | Light-on-dark contrast cap (< 21 → OKCA strictly below WCAG, FP=0 by construction) |
 | `DOL_CAP` | 20 | Dark-on-light contrast cap (< LOD_CAP); proportional polarity penalty |
 
 **Calibration anchors:**
 
-- **`C_THRESH` = 0.15** --- Typical Oklab chroma for designer palette saturated colours; lightly tinted neutrals (C < 0.05) receive less than 10% of the full penalty.
+- **`C_THRESH` = 0.15** --- Typical Oklab chroma for designer palette saturated colours; lightly tinted neutrals ($C < 0.05$) receive less than 10% of the full penalty.
 
-- **`CHROMA_K` = 0.65** --- Yields exp = 1.65 at full saturation. Combined with the polarity factor, hot pink/near-black scores 3.6 and dark orange/near-black scores 4.2 --- both below the 4.5 AA threshold, where WCAG rates them 6.6 and 7.5 (two of WCAG's most-cited false passes). Raised from 0.50 alongside the 3.9 anchor move: the anchor lowered `POL_K` (which lifts all scores globally, including these saturated catches), and the stronger chroma penalty re-docks vivid saturated foregrounds to their intended sub-AA scores. Because the penalty acts only on the lighter element, this leaves the achromatic anchors and the (white-lighter) design-system disagreement counts untouched.
+- **`CHROMA_K` = 0.65** --- Yields $\text{exp} = 1.65$ at full saturation. Combined with the polarity factor, hot pink/near-black scores 3.6 and dark orange/near-black scores 4.2 --- both below the 4.5 AA threshold, where WCAG rates them 6.6 and 7.5 (two of WCAG's most-cited false passes). Raised from 0.50 alongside the 3.9 anchor move: the anchor lowered `POL_K` (which lifts all scores globally, including these saturated catches), and the stronger chroma penalty re-docks vivid saturated foregrounds to their intended sub-AA scores. Because the penalty acts only on the lighter element, this leaves the achromatic anchors and the (white-lighter) design-system disagreement counts untouched.
 
 - **`POL_K` = 1.100** --- Calibrated so white/`#767676` (WCAG AA boundary grey) scores 3.9 under L-o-D (raised from a 3.5 anchor / `POL_K` 1.175 to reduce over-conservatism on mid-range chromatics). Derived: $k = \ln(3.9/21) / \ln(4.54/21) \approx 1.0996$.
 
-- **`LOD_CAP` = 20.9** --- Light-on-dark cap, one notch below 21. This is the strict-margin lever for the FP=0 proof: with the cap below 21 the identity `21^(1−k)·A(white)·B(black) = 1` becomes `LOD_CAP/21 = 0.99524 < 1`, removing the single white-on-black equality point so OKCA is strictly below WCAG everywhere (Section 4). White on black: 20.9.
+- **`LOD_CAP` = 20.9** --- Light-on-dark cap, one notch below 21. This is the strict-margin lever for the FP=0 proof: with the cap below 21 the identity $21^{1-k} \cdot A(\text{white}) \cdot B(\text{black}) = 1$ becomes $\text{LOD\_CAP}/21 = 0.99524 < 1$, removing the single white-on-black equality point so OKCA is strictly below WCAG everywhere (Section 4). White on black: 20.9.
 
 - **`DOL_CAP` = 20** --- Proportional polarity penalty for D-o-L: at any given raw ratio, D-o-L scores $(20/20.9) \approx 96\%$ of the equivalent L-o-D score. Black on white: 20.0. `#767676` on white: $(20/20.9) \times 3.9 \approx 3.7$.
 

--- a/docs/OKCA_EXECUTIVE_BRIEF.md
+++ b/docs/OKCA_EXECUTIVE_BRIEF.md
@@ -77,13 +77,16 @@ false passes against WCAG 2.x** — it never approves a pair WCAG rejects.
 The guarantee is **verified for the full sRGB gamut** — not calibration-dependent
 headroom. The argument has three parts:
 
-- **Algebraic reduction.** `OKCA ≤ WCAG` separates into two single-element
-  factors: it is equivalent to `(CAP/21^k)·A(lighter)·B(darker) ≤ 1`.
-- **An exact identity.** At the achromatic anchors, `21^(1−k)·A(white)·B(black) = 1`
-  for any k. Because the light-on-dark cap is set just below 21 (`LOD_CAP = 20.9`),
-  the anchor bound is `20.9/21 = 0.99524 < 1` — a strict margin, so OKCA is
-  *strictly* below WCAG everywhere (no equality point).
-- **Two verified lemmas.** `A(l) ≤ A(white)` and `B(d) ≤ B(black)` are each
+- **Algebraic reduction.** $\text{OKCA} \le \text{WCAG}$ separates into two
+  single-element factors: it is equivalent to
+  $(\text{CAP}/21^{k}) \cdot A(\text{lighter}) \cdot B(\text{darker}) \le 1$.
+- **An exact identity.** At the achromatic anchors,
+  $21^{1-k} \cdot A(\text{white}) \cdot B(\text{black}) = 1$ for any $k$. Because
+  the light-on-dark cap is set just below 21 (`LOD_CAP = 20.9`), the anchor bound
+  is $20.9/21 = 0.99524 < 1$ — a strict margin, so OKCA is *strictly* below WCAG
+  everywhere (no equality point).
+- **Two verified lemmas.** $A(l) \le A(\text{white})$ and
+  $B(d) \le B(\text{black})$ are each
   confirmed by interval arithmetic over the sRGB cube with **0 uncertified boxes**
   — a machine-checked proof over continuous regions, not a sample.
 
@@ -116,7 +119,7 @@ pairs.
 
 | Property | WCAG 2.x | OKCA |
 |---|---|---|
-| Luminance input | IEC 61966-2-1 sRGB | OKLCH L³ (Oklab) |
+| Luminance input | IEC 61966-2-1 sRGB | OKLCH $L^3$ (Oklab) |
 | Scale | 1–21 | 1–21 |
 | AA / AAA thresholds | 4.5 / 7.0 | 4.5 / 7.0 |
 | Polarity | Symmetric | Asymmetric |

--- a/docs/WCAG_DISAGREEMENTS.md
+++ b/docs/WCAG_DISAGREEMENTS.md
@@ -6,7 +6,7 @@
 > anchor at 3.9 (`POL_K = 1.100`) and the light-on-dark cap lowered to `LOD_CAP
 > = 20.9` (which keeps OKCA strictly below WCAG — white-on-black = 20.9, not 21 —
 > so FP=0 is guaranteed by construction; see `docs/FP0_PROOF.md`). The lowered
-> cap scales light-on-dark scores by 20.9/21 (dark-on-light is unaffected); the
+> cap scales light-on-dark scores by $20.9/21$ (dark-on-light is unaffected); the
 > disagreement membership is unchanged from the 3.9 recalibration. FP=0 holds
 > across the full sRGB gamut (interval-verified).
 
@@ -18,7 +18,7 @@
 | GOV.UK Design System | govuk-frontend (MIT) | [github.com/alphagov/govuk-frontend](https://github.com/alphagov/govuk-frontend) `_colours-palette.scss` |
 | US Web Design System | USWDS v3.x (MIT) | [github.com/uswds/uswds](https://github.com/uswds/uswds) `packages/uswds-core/src/styles/tokens/color/` |
 
-All 97 are pairs where OKCA scores below 4.5 AA but WCAG scores ≥ 4.5. These are intentional — they represent colours in the marginal zone that WCAG's threshold passes but real-world practitioners routinely reject. Each colour is scored twice due to OKCA's polarity model — once as a L-o-D pair (white text on colour) and once as a D-o-L pair (colour on white) — and counted separately; a "D-o-L only" note marks colours where just one direction falls below 4.5.
+All 97 are pairs where OKCA scores below 4.5 AA but WCAG scores $\ge 4.5$. These are intentional — they represent colours in the marginal zone that WCAG's threshold passes but real-world practitioners routinely reject. Each colour is scored twice due to OKCA's polarity model — once as a L-o-D pair (white text on colour) and once as a D-o-L pair (colour on white) — and counted separately; a "D-o-L only" note marks colours where just one direction falls below 4.5.
 
 WCAG score shown is symmetric. OKCA scores differ by polarity — L-o-D is always slightly higher than D-o-L for the same colour.
 
@@ -73,7 +73,7 @@ GOV.UK makes explicit WCAG 2.2 AA claims and documents approved text pairings. T
 
 ## USWDS v3.x — 50 disagreements
 
-USWDS makes explicit WCAG 2.x AA claims. The 50 disagreements are the grade-50 shade across every chromatic family plus all three gray families. Grade 50 is calibrated to land at WCAG ≈ 4.6 system-wide — just above the 4.5 threshold.
+USWDS makes explicit WCAG 2.x AA claims. The 50 disagreements are the grade-50 shade across every chromatic family plus all three gray families. Grade 50 is calibrated to land at WCAG $\approx 4.6$ system-wide — just above the 4.5 threshold.
 
 | Family | Hex | WCAG | OKCA L-o-D | OKCA D-o-L |
 |--------|-----|-----:|----------:|----------:|
@@ -117,7 +117,7 @@ USWDS makes explicit WCAG 2.x AA claims. The 50 disagreements are the grade-50 s
 
 ### Where OKCA consistently disagrees
 1. **Gray 500 zone** — the entire Tailwind neutral scale at 500 (~4.7–4.8 WCAG, OKCA 3.9–4.2). The most important disagreements from a practitioner standpoint.
-2. **USWDS grade 50 across all families** — calibrated to WCAG ≈ 4.6 system-wide. A single threshold shift of 0.1 WCAG points separates these from USWDS grade 40 (which passes both).
+2. **USWDS grade 50 across all families** — calibrated to WCAG $\approx 4.6$ system-wide. A single threshold shift of 0.1 WCAG points separates these from USWDS grade 40 (which passes both).
 3. **Saturated chromatics at medium depth** — high-chroma hues near the WCAG boundary (fuchsia, pink, magenta, red). The chroma compression penalty is largest here.
 4. **Blue / indigo / purple hues** — perceptually darker than luminance alone predicts.
 

--- a/src/__tests__/docs-lint.spec.ts
+++ b/src/__tests__/docs-lint.spec.ts
@@ -5,8 +5,12 @@
  * These run as part of the normal test suite so CI catches them.
  *
  * Scope: every `docs/*.md` file. Math in these docs is authored in LaTeX and
- * rendered by GitHub with KaTeX, so the checks below target the ways that
- * pipeline silently breaks.
+ * rendered by GitHub, which runs its Markdown pass BEFORE handing the result
+ * to KaTeX. That two-stage pipeline is what the checks below target: Markdown
+ * silently rewrites the TeX, and the damage is only visible on github.com.
+ *
+ * The rules were established empirically by rendering probe documents through
+ * GitHub's own markdown API and parsing what came back with KaTeX.
  */
 import * as fs from 'fs';
 import * as path from 'path';
@@ -18,74 +22,132 @@ const MD_FILES = fs
   .filter((f) => f.endsWith('.md'))
   .sort();
 
-/**
- * Blank out fenced code blocks. Math delimiters inside them are literal text,
- * not math, so none of the checks below should look at them.
- */
-function maskCodeFences(lines: string[]): string[] {
-  let inFence = false;
-  return lines.map((line) => {
-    if (/^\s*```/.test(line)) {
-      inFence = !inFence;
-      return '';
-    }
-    return inFence ? '' : line;
-  });
+interface Line {
+  n: number;
+  text: string;
+  /** Inside a multi-line `$$` block, which Markdown passes through literally. */
+  literalMath: boolean;
 }
 
 /**
- * Check a list of lines for \texttt{*_*} inside $...$ math spans.
- * Returns violation strings (human-readable) for each offending line.
+ * Blank out fenced code blocks and mark multi-line `$$` blocks.
  *
- * The renderer treats _ as a subscript operator in math context, even inside
- * \texttt{}. The fix is always to split the math span:
- * $k =$ `FOO` $= v$.
+ * A `$$...$$` block written across several lines is handed to KaTeX verbatim,
+ * so it is exempt from the escape rules below. A single-line `$$...$$` is NOT
+ * — Markdown processes it like any other inline content.
  */
-function findTextttInMath(lines: string[], filename: string): string[] {
-  const violations: string[] = [];
-  for (let i = 0; i < lines.length; i++) {
-    const mathSpans = lines[i].matchAll(/\$([^$]+)\$/g);
-    for (const match of mathSpans) {
-      if (/\\texttt\{[^}]*_[^}]*\}/.test(match[1])) {
-        violations.push(`${filename}:${i + 1}: ${lines[i].trim()}`);
-      }
+function scan(src: string): Line[] {
+  const out: Line[] = [];
+  let inFence = false;
+  let inBlockMath = false;
+
+  src.split('\n').forEach((text, i) => {
+    const n = i + 1;
+    if (/^\s*```/.test(text)) {
+      inFence = !inFence;
+      return;
+    }
+    if (inFence) return;
+
+    const delims = (text.match(/\$\$/g) || []).length;
+    if (inBlockMath) {
+      out.push({ n, text, literalMath: true });
+      if (delims >= 1) inBlockMath = false;
+      return;
+    }
+    if (delims === 1) {
+      inBlockMath = true;
+      out.push({ n, text, literalMath: true });
+      return;
+    }
+    out.push({ n, text, literalMath: false });
+  });
+
+  return out;
+}
+
+const mathSpans = (text: string) => [...text.matchAll(/\$\$?([^$]+)\$\$?/g)].map((m) => m[1]);
+
+/**
+ * \texttt{} containing an underscore inside math. The renderer treats _ as a
+ * subscript operator even inside \texttt{}. Split the span instead:
+ * $k =$ `POL_K` $= 1.100$.
+ */
+function findTextttInMath(lines: Line[]): string[] {
+  const bad: string[] = [];
+  for (const line of lines) {
+    for (const span of mathSpans(line.text)) {
+      if (/\\texttt\{[^}]*_[^}]*\}/.test(span)) bad.push(`${line.n}: ${line.text.trim()}`);
     }
   }
-  return violations;
+  return bad;
 }
 
 /**
- * An odd number of unescaped `$` on a line means a math span is unclosed or
- * wraps onto the next line. GitHub does not render an inline span that spans a
- * newline, so both cases are bugs — reflow the span onto one line.
+ * An odd number of unescaped `$` means a span is unclosed or wraps onto the
+ * next line. GitHub will not render an inline span that spans a newline.
  */
-function findUnbalancedDollars(lines: string[], filename: string): string[] {
-  const violations: string[] = [];
-  for (let i = 0; i < lines.length; i++) {
-    const dollars = lines[i].match(/(?<!\\)\$/g);
-    if (dollars && dollars.length % 2 !== 0) {
-      violations.push(`${filename}:${i + 1}: ${lines[i].trim()}`);
-    }
-  }
-  return violations;
+function findUnbalancedDollars(lines: Line[]): string[] {
+  return lines
+    .filter((l) => !l.literalMath)
+    .filter((l) => {
+      const d = l.text.match(/(?<!\\)\$/g);
+      return d && d.length % 2 !== 0;
+    })
+    .map((l) => `${l.n}: ${l.text.trim()}`);
 }
 
 /**
- * `\{` and `\}` inside math are consumed by the Markdown escape pass before
- * KaTeX sees them, so the braces silently turn into grouping rather than
- * literal set braces. `\lbrace` / `\rbrace` survive the round trip.
+ * Backslash-escaped punctuation inside a single-line math span. Markdown eats
+ * the backslash before KaTeX sees it, so `\_`->`_` and `\%`->`%` become parse
+ * errors, while `\,`->`,` `\;`->`;` `\\`->`\` silently render the wrong glyph.
+ *
+ * Use letter-named commands, which survive: \thinspace, \quad, \lbrace,
+ * \rbrace. For `\\` row breaks, write the `$$` block across multiple lines.
  */
-function findEscapedBracesInMath(lines: string[], filename: string): string[] {
-  const violations: string[] = [];
-  for (let i = 0; i < lines.length; i++) {
-    const mathSpans = lines[i].matchAll(/\$([^$]+)\$/g);
-    for (const match of mathSpans) {
-      if (/\\[{}]/.test(match[1])) {
-        violations.push(`${filename}:${i + 1}: ${lines[i].trim()}`);
+function findMarkdownEatenEscapes(lines: Line[]): string[] {
+  const bad: string[] = [];
+  for (const line of lines) {
+    if (line.literalMath) continue;
+    for (const span of mathSpans(line.text)) {
+      const hits = span.match(/\\\\|\\[_,;%{}]/g);
+      if (hits) {
+        bad.push(`${line.n}: uses ${[...new Set(hits)].join(' ')} :: ${line.text.trim()}`);
       }
     }
   }
-  return violations;
+  return bad;
+}
+
+/**
+ * A `$` delimiter directly against `"`, `-`, `/` or a single `*` stops GitHub
+ * recognising the span as math at all — it renders as literal `$...$` text.
+ * (Bold `**` is fine.) Put a space in, or reword.
+ */
+function findBadDelimiterAdjacency(lines: Line[]): string[] {
+  const bad: string[] = [];
+  for (const line of lines) {
+    if (line.literalMath) continue;
+    for (const m of line.text.matchAll(/(.)?\$[^$\n]+\$(.)?/g)) {
+      const [, before, after] = m;
+      const offenders: string[] = [];
+      // A single `*` breaks it; `**` (bold) does not.
+      const isSingleStar = (ch: string, side: 'before' | 'after') => {
+        if (ch !== '*') return false;
+        const i = m.index! + (side === 'before' ? 0 : m[0].length - 1);
+        const neighbour = side === 'before' ? line.text[i - 1] : line.text[i + 1];
+        return neighbour !== '*';
+      };
+      if (before && (/["\-/]/.test(before) || isSingleStar(before, 'before'))) {
+        offenders.push(`before='${before}'`);
+      }
+      if (after && (/["\-/]/.test(after) || isSingleStar(after, 'after'))) {
+        offenders.push(`after='${after}'`);
+      }
+      if (offenders.length) bad.push(`${line.n}: ${offenders.join(' ')} :: ${line.text.trim()}`);
+    }
+  }
+  return bad;
 }
 
 describe('docs-lint', () => {
@@ -94,20 +156,22 @@ describe('docs-lint', () => {
   });
 
   describe.each(MD_FILES)('%s', (filename) => {
-    const lines = maskCodeFences(
-      fs.readFileSync(path.join(DOCS_DIR, filename), 'utf8').split('\n'),
-    );
+    const lines = scan(fs.readFileSync(path.join(DOCS_DIR, filename), 'utf8'));
 
-    it('has no \\texttt{} containing underscores inside $...$ math', () => {
-      expect(findTextttInMath(lines, filename)).toEqual([]);
+    it('has no \\texttt{} containing underscores inside math', () => {
+      expect(findTextttInMath(lines)).toEqual([]);
     });
 
     it('has balanced $ math delimiters on every line', () => {
-      expect(findUnbalancedDollars(lines, filename)).toEqual([]);
+      expect(findUnbalancedDollars(lines)).toEqual([]);
     });
 
-    it('uses \\lbrace/\\rbrace rather than \\{ \\} inside math', () => {
-      expect(findEscapedBracesInMath(lines, filename)).toEqual([]);
+    it('has no backslash-escaped punctuation inside single-line math', () => {
+      expect(findMarkdownEatenEscapes(lines)).toEqual([]);
+    });
+
+    it('has no $ delimiter jammed against " - / or a single *', () => {
+      expect(findBadDelimiterAdjacency(lines)).toEqual([]);
     });
   });
 });

--- a/src/__tests__/docs-lint.spec.ts
+++ b/src/__tests__/docs-lint.spec.ts
@@ -3,19 +3,43 @@
  * easy to introduce during updates but hard to spot by eye.
  *
  * These run as part of the normal test suite so CI catches them.
+ *
+ * Scope: every `docs/*.md` file. Math in these docs is authored in LaTeX and
+ * rendered by GitHub with KaTeX, so the checks below target the ways that
+ * pipeline silently breaks.
  */
 import * as fs from 'fs';
 import * as path from 'path';
 
-const MD_FILE = path.resolve(__dirname, '../../docs/OKCA_DESIGN.md');
+const DOCS_DIR = path.resolve(__dirname, '../../docs');
+
+const MD_FILES = fs
+  .readdirSync(DOCS_DIR)
+  .filter((f) => f.endsWith('.md'))
+  .sort();
+
+/**
+ * Blank out fenced code blocks. Math delimiters inside them are literal text,
+ * not math, so none of the checks below should look at them.
+ */
+function maskCodeFences(lines: string[]): string[] {
+  let inFence = false;
+  return lines.map((line) => {
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      return '';
+    }
+    return inFence ? '' : line;
+  });
+}
 
 /**
  * Check a list of lines for \texttt{*_*} inside $...$ math spans.
  * Returns violation strings (human-readable) for each offending line.
  *
- * Applies to the .md design doc (GitHub KaTeX): the renderer treats _ as a
- * subscript operator in math context, even inside \texttt{}. The fix is
- * always to split the math span: $k =$ \texttt{FOO} $= v$.
+ * The renderer treats _ as a subscript operator in math context, even inside
+ * \texttt{}. The fix is always to split the math span:
+ * $k =$ `FOO` $= v$.
  */
 function findTextttInMath(lines: string[], filename: string): string[] {
   const violations: string[] = [];
@@ -30,12 +54,60 @@ function findTextttInMath(lines: string[], filename: string): string[] {
   return violations;
 }
 
+/**
+ * An odd number of unescaped `$` on a line means a math span is unclosed or
+ * wraps onto the next line. GitHub does not render an inline span that spans a
+ * newline, so both cases are bugs — reflow the span onto one line.
+ */
+function findUnbalancedDollars(lines: string[], filename: string): string[] {
+  const violations: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const dollars = lines[i].match(/(?<!\\)\$/g);
+    if (dollars && dollars.length % 2 !== 0) {
+      violations.push(`${filename}:${i + 1}: ${lines[i].trim()}`);
+    }
+  }
+  return violations;
+}
+
+/**
+ * `\{` and `\}` inside math are consumed by the Markdown escape pass before
+ * KaTeX sees them, so the braces silently turn into grouping rather than
+ * literal set braces. `\lbrace` / `\rbrace` survive the round trip.
+ */
+function findEscapedBracesInMath(lines: string[], filename: string): string[] {
+  const violations: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const mathSpans = lines[i].matchAll(/\$([^$]+)\$/g);
+    for (const match of mathSpans) {
+      if (/\\[{}]/.test(match[1])) {
+        violations.push(`${filename}:${i + 1}: ${lines[i].trim()}`);
+      }
+    }
+  }
+  return violations;
+}
+
 describe('docs-lint', () => {
-  it('has no \\texttt{} containing underscores inside $...$ math (md)', () => {
-    const mdLines = fs.readFileSync(MD_FILE, 'utf8').split('\n');
+  it('finds markdown files to check', () => {
+    expect(MD_FILES.length).toBeGreaterThan(0);
+  });
 
-    const violations = findTextttInMath(mdLines, 'OKCA_DESIGN.md');
+  describe.each(MD_FILES)('%s', (filename) => {
+    const lines = maskCodeFences(
+      fs.readFileSync(path.join(DOCS_DIR, filename), 'utf8').split('\n'),
+    );
 
-    expect(violations).toEqual([]);
+    it('has no \\texttt{} containing underscores inside $...$ math', () => {
+      expect(findTextttInMath(lines, filename)).toEqual([]);
+    });
+
+    it('has balanced $ math delimiters on every line', () => {
+      expect(findUnbalancedDollars(lines, filename)).toEqual([]);
+    });
+
+    it('uses \\lbrace/\\rbrace rather than \\{ \\} inside math', () => {
+      expect(findEscapedBracesInMath(lines, filename)).toEqual([]);
+    });
   });
 });


### PR DESCRIPTION
Closes #17.

Authors all maths in `docs/` in LaTeX, and fixes the LaTeX that was already
there but broken on github.com.

## The root cause

GitHub runs its **Markdown pass first**, then hands the result to KaTeX. Markdown
rewrites the TeX before the renderer ever sees it. Validating the *source* with
KaTeX locally therefore passes things that are broken in production — which is
how the existing breakage got in.

Backslash-escaped punctuation inside a single-line math span does not survive:

| Source | After Markdown | Effect |
|---|---|---|
| `\_` | `_` | hard parse error |
| `\%` | `%` | starts a comment, swallows the span |
| `\,` `\;` `\` | `,` `;` `\` | silently renders the wrong glyph |

A multi-line `$$` block is passed through literally and is exempt. A *single-line*
`$$...$$` is not. Separately, a `$` jammed against `"`, `-`, `/`, or a single `*`
stops GitHub recognising the span at all, so it prints literal `$...$`.

## Pre-existing breakage fixed

Wrong on github.com before this branch, all in `OKCA_DESIGN.md`:

- `\text{POL\_K}` / `\text{LOD\_CAP}` — parse errors. The old CLAUDE.md rule
  banned `\texttt{}`, but the `\text{}` form fails identically; the rule had
  caught the symptom, not the cause.
- `\approx 96\%` — the `%` commented out the rest of the span.
- The polarity `cases` block on one line — `\` collapsed to `\`, destroying the
  row break, so only one row rendered.
- `(same-$Y$ grey)` and `"$L^3 = ...$` — printed as literal `$...$`.

## Changes

- Constants leave math entirely. `FP0_PROOF.md` uses `$c$` for the light-on-dark
  cap, with `LOD_CAP` named in prose.
- `\thinspace` / `\quad` replace `\,` / `\;`; `\lbrace` / `\rbrace` replace
  `\{` / `\}` — letter-named commands survive the Markdown pass.
- The `cases` block moved to a multi-line `$$` block; percentages moved to prose.
- `FP0_PROOF.md` converted wholesale from code-fence ASCII to LaTeX, adopting the
  design-doc symbols ($Y_{\text{lighter}}$, $r_{\text{raw}}$, $Y_l$ / $Y_d$).
- `docs-lint.spec.ts` now globs every `docs/*.md` (it was hardcoded to
  `OKCA_DESIGN.md`) and gained the two rules this exposed.
- CLAUDE.md documents the pipeline as the root cause, with a `gh api` recipe for
  checking real rendered output.

## Verification

Rules were derived empirically — probe documents through GitHub's markdown API,
diffing what came back — not guessed.

- **232 spans through GitHub's markdown API: 0 KaTeX failures, 0 unrecognised.**
  Before the second commit: 10 parse failures, 11 unrecognised.
- **All six pages loaded in a real browser on the pushed branch: 232
  `math-renderer` elements, all rendered to MathML, 0 failures, no literal
  `$...$` anywhere.** Counts match the API exactly.
- Lint rules confirmed to fire against a planted file containing all 11 bad
  constructs; bold `**`, multi-line blocks and letter-named commands stay clean.
- Presentation-only: the numeric-token multiset of every file was diffed
  before/after; all deltas trace to formatting (`1e-12`→`10^{-12}`, `L³`→`L^3`).
- Full suite: **2,279 passing**.

No `src/` behaviour change — docs and a test file only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bh6vqR5bcAvzTs5KeuboSr
