### PR TITLE
fix: make the ESM entry point load under native Node ESM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,21 @@ Shared symbols, so the docs read as one notation: $L^3$, $\delta$, $Y$,
 $Y_{\text{lighter}}$ / $Y_{\text{darker}}$ (OKCA proxies) vs $Y_l$ / $Y_d$
 (WCAG luminances), $r_{\text{raw}}$, $\text{CAP}$, $k$, $A(l)$, $B(d)$.
 
+### Scope — `docs/` only, deliberately
+
+`README.md` and `src/index.ts` are **excluded on purpose**. Both contain
+algorithm descriptions and both look like unfinished conversions. They are not.
+
+- **`README.md` must stay free of `$` math.** It is the npm package page, and
+  **npmjs.com does not render GitHub's math syntax** — LaTeX there prints as
+  literal `$...$` to every visitor. Use Unicode (`≤`, `≥`) or backticked code,
+  which render correctly on both npm and GitHub.
+- **`src/index.ts` is a source comment**, not Markdown. ASCII (`sqrt(a² + b²)`,
+  `L³`) is right there; nothing renders it.
+
+So the notation rule is scoped to `docs/*.md`, and `docs-lint.spec.ts` globs
+exactly that. Widening either the rule or the lint glob breaks the npm listing.
+
 ### The one thing to understand
 
 GitHub runs its **Markdown pass first**, then hands the result to KaTeX. So

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,10 @@
 module.exports = {
   testRegex: '.*\\.spec\\.ts$',
+  // src/ imports carry .js extensions so the ESM build emits valid specifiers;
+  // map them back to the .ts sources jest actually resolves.
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
   transform: {
     '^.+\\.ts$': [
       'ts-jest',

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc && tsc -p tsconfig.esm.json",
+    "build": "tsc && tsc -p tsconfig.esm.json && node scripts/finalize-esm.mjs",
     "test": "jest",
     "calibrate": "tsc -p tsconfig.scripts.json && node dist-scripts/scripts/calibration-sweep.js",
     "hue": "tsc -p tsconfig.scripts.json && node dist-scripts/scripts/hue-analysis.js",

--- a/scripts/finalize-esm.mjs
+++ b/scripts/finalize-esm.mjs
@@ -1,0 +1,22 @@
+/**
+ * Marks dist/esm as ESM.
+ *
+ * The root package.json has no "type" field, so Node treats every .js file in
+ * the package as CommonJS — including dist/esm/, which exports.import points at.
+ * Dropping a package.json with {"type": "module"} into that directory scopes the
+ * ESM declaration to it, leaving the CJS build in dist/ untouched.
+ *
+ * Without this, `import` from native Node ESM fails: on Node <22.7 with
+ * "Cannot use import statement outside a module", and on newer Node with a
+ * resolution error once syntax detection reparses the file.
+ */
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const esmDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'dist', 'esm');
+
+mkdirSync(esmDir, { recursive: true });
+writeFileSync(join(esmDir, 'package.json'), JSON.stringify({ type: 'module' }, null, 2) + '\n');
+
+console.log('wrote dist/esm/package.json ({"type":"module"})');

--- a/src/__tests__/package-entrypoints.spec.ts
+++ b/src/__tests__/package-entrypoints.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * Guards the published entry points (issue #19).
+ *
+ * The suite elsewhere imports `src/` directly, so it never exercises what
+ * consumers actually load. That gap let a broken ESM build ship for three
+ * releases: `dist/esm/` emitted extensionless relative specifiers, and nothing
+ * marked the directory as ESM, so `import` from native Node ESM failed.
+ *
+ * These tests run against built output, spawning a real node process so
+ * resolution is Node's, not jest's. CI builds before testing and runs the
+ * matrix on Node 18/20/22, which is where the version-dependent failure modes
+ * would surface.
+ */
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '../..');
+const DIST = path.join(ROOT, 'dist');
+const ESM_DIR = path.join(DIST, 'esm');
+
+const built = fs.existsSync(path.join(ESM_DIR, 'index.js'));
+
+// Local `npm test` on a fresh clone has no dist/ yet; CI always builds first.
+const describeBuilt = built ? describe : describe.skip;
+
+if (!built) {
+  console.warn('[package-entrypoints] dist/ not built — skipping. Run `npm run build` first.');
+}
+
+/** Run a snippet in a real node process and return its stdout. */
+function node(source: string, ext: 'mjs' | 'cjs'): string {
+  const file = path.join(DIST, `__entrypoint-check.${ext}`);
+  fs.writeFileSync(file, source);
+  try {
+    return execFileSync(process.execPath, [file], { encoding: 'utf8' }).trim();
+  } finally {
+    fs.unlinkSync(file);
+  }
+}
+
+const toUrl = (p: string) => 'file:///' + p.replace(/\\/g, '/');
+
+describeBuilt('published entry points', () => {
+  describe('dist/esm (the "import" condition)', () => {
+    it('is marked as ESM by its own package.json', () => {
+      const pkg = JSON.parse(fs.readFileSync(path.join(ESM_DIR, 'package.json'), 'utf8'));
+      expect(pkg.type).toBe('module');
+    });
+
+    it('emits no extensionless relative specifiers', () => {
+      const offenders: string[] = [];
+      for (const f of fs.readdirSync(ESM_DIR).filter((f) => f.endsWith('.js'))) {
+        const src = fs.readFileSync(path.join(ESM_DIR, f), 'utf8');
+        for (const m of src.matchAll(/from\s+'(\.[^']*)'/g)) {
+          if (!m[1].endsWith('.js')) offenders.push(`${f}: ${m[1]}`);
+        }
+      }
+      expect(offenders).toEqual([]);
+    });
+
+    it('loads under native node ESM and computes correctly', () => {
+      const out = node(
+        `import { contrast, OkcaService } from ${JSON.stringify(toUrl(path.join(ESM_DIR, 'index.js')))};\n` +
+          `console.log(JSON.stringify([contrast('#ffffff','#000000'), new OkcaService().contrast('#000000','#ffffff')]));`,
+        'mjs',
+      );
+      expect(JSON.parse(out)).toEqual([20.9, 20]);
+    });
+  });
+
+  describe('dist (the "require" condition)', () => {
+    it('loads under CJS and computes correctly', () => {
+      const out = node(
+        `const { contrast, OkcaService } = require(${JSON.stringify(path.join(DIST, 'index.js'))});\n` +
+          `console.log(JSON.stringify([contrast('#ffffff','#000000'), new OkcaService().contrast('#000000','#ffffff')]));`,
+        'cjs',
+      );
+      expect(JSON.parse(out)).toEqual([20.9, 20]);
+    });
+  });
+
+  it('every path in the exports map exists', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+    const targets = [
+      ...Object.values(pkg.exports['.'] as Record<string, string>),
+      pkg.main,
+      pkg.module,
+      pkg.types,
+    ];
+    const missing = targets.filter((t) => !fs.existsSync(path.join(ROOT, t)));
+    expect(missing).toEqual([]);
+  });
+});

--- a/src/__tests__/package-entrypoints.spec.ts
+++ b/src/__tests__/package-entrypoints.spec.ts
@@ -43,6 +43,14 @@ const toUrl = (p: string) => 'file:///' + p.replace(/\\/g, '/');
 
 describeBuilt('published entry points', () => {
   describe('dist/esm (the "import" condition)', () => {
+    /**
+     * NOT redundant with the load test below — do not remove as duplicate
+     * coverage. Node >= 22.7 detects ESM syntax and reparses, so a missing
+     * "type" still loads there once specifiers are valid; the load test only
+     * catches this on Node 18/20. This assertion is the one that holds on
+     * every version. Verified by deleting dist/esm/package.json: on Node 24
+     * this test fails alone while the load test still passes.
+     */
     it('is marked as ESM by its own package.json', () => {
       const pkg = JSON.parse(fs.readFileSync(path.join(ESM_DIR, 'package.json'), 'utf8'));
       expect(pkg.type).toBe('module');

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@
  *     same color pair; direction is a design input, not a symmetric quantity
  *   - Pure OKLCH/Oklab — no WCAG luminance formula, no hue-specific patches
  */
-import { hexToOklab, cssOklabToOklab, cssOklchToOklch, oklchToOklab } from './transforms';
+import { hexToOklab, cssOklabToOklab, cssOklchToOklch, oklchToOklab } from './transforms.js';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 const C_THRESH = 0.15;  // Oklab chroma for full lighter-element penalty
@@ -122,4 +122,4 @@ export {
   hexToOklab, hexToOklch, hexToSrgb, srgbToOklab, srgbToOklch,
   oklchToOklab, oklabToOklch,
   cssOklabToOklab, cssOklchToOklch,
-} from './transforms';
+} from './transforms.js';


### PR DESCRIPTION
Closes #19.

`import { contrast } from '@pawn002/okca'` failed on a clean install from the
registry. Two independent defects in the ESM build, either of which alone breaks
it:

1. **Extensionless relative specifiers.** `tsc` does not rewrite specifiers, so
   `dist/esm/index.js` emitted `from './transforms'`. Node ESM requires the
   extension.
2. **Nothing marked `dist/esm/` as ESM.** No `package.json` with
   `{"type": "module"}` there, and no `"type"` at the root — so Node treated the
   files `exports.import` points at as CommonJS.

Present since at least 1.0.2. Bundlers hid it by resolving extensionless
specifiers themselves, and the test suite only ever imported `src/`.

Took route **A** from the issue (fix the dual build) rather than B (ship CJS
only), so native ESM consumers are supported rather than dropped.

## Changes

- **`src/index.ts`** — relative imports carry `.js`. Correct for the CJS target
  too: it emits `require("./transforms.js")`, which resolves in `dist/`.
- **`scripts/finalize-esm.mjs`** — writes `dist/esm/package.json` with
  `{"type":"module"}`, scoping the ESM declaration to that directory and leaving
  `dist/` as CommonJS. Plain `.mjs`; no new dependency.
- **`jest.config.js`** — `moduleNameMapper` maps `.js` specifiers back to `.ts`.
- **`src/__tests__/package-entrypoints.spec.ts`** — new regression guard.

`scripts/*.ts` deliberately untouched: they compile to CJS in `dist-scripts/` and
are not shipped, so extensionless imports there are harmless.

## Verified as a consumer

Packed the tarball and installed it into a clean project — not just inspected the
build:

| | `require` | native `import` |
|---|---|---|
| white/black | 20.9 | 20.9 |
| white/`#767676` | 3.9 | 3.9 |
| black/white | 20 | 20 |

Identical across both conditions and matching the documented anchors.
`dist/esm/package.json` is present in the tarball.

## The regression guard, and one subtlety

`package-entrypoints.spec.ts` runs against built output in a real node process,
so resolution is Node's rather than jest's. I confirmed it fires by planting both
original defects back into `dist/`: with both present, all three relevant tests
fail.

Planting only the missing `type: module`, though, **still loads fine on Node 24**
— syntax detection reparses the file once specifiers are valid. Only the static
assertion caught it locally. So the runtime check alone would have been a false
all-clear on modern Node; the two assertions are not redundant, and that is now
documented on the test so it does not get "tidied up" later. CI's Node 18/20 legs
are where the runtime failure actually surfaces, which is the main thing this PR
needs from CI.

Suite: **2,284 passing** (+5).

The spec skips with a warning when `dist/` is absent so `npm test` still works on
a fresh clone; CI builds before testing, so coverage is real there.

## Also in this branch

`0d54668` is unrelated to #19 — a CLAUDE.md note recording why `README.md` and
`src/index.ts` are deliberately excluded from the LaTeX rule (npmjs.com does not
render GitHub math syntax, and a source comment is not Markdown). Folded in
rather than pushed to main on its own.

## Follow-up

This does not change `contrast()` output, so it is a patch. Worth releasing
promptly — 2.0.1 and every earlier version are broken for native ESM consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bh6vqR5bcAvzTs5KeuboSr
