### PR TITLE
docs: flag the moved anchors in CALIBRATION_EXPERIMENT, and assert them in CI

### DIFF
--- a/docs/CALIBRATION_EXPERIMENT.md
+++ b/docs/CALIBRATION_EXPERIMENT.md
@@ -8,8 +8,29 @@ Tailwind 46→34, GOV.UK 15→13, USWDS 50→50) while preserving FP=0. Because 
 global `POL_K` lift also loosened OKCA's saturated-colour catches, the chroma
 penalty was strengthened in tandem (**`CHROMA_K` 0.50 → 0.65**) to re-dock vivid
 foregrounds — a lever cleanly decoupled from the grey recovery. See
-**§8 — Applied change** below. The body (§1–§7) records the method and data
-that led there; the tables in §5–§6 use the pre-change baseline.
+**§8 — Applied change** below. A second, separate step then lowered the
+light-on-dark cap (**`LOD_CAP` 21 → 20.9**, issue #14) to make FP=0 a theorem
+rather than a gamut-verified property — see **§9**.
+
+The body (§1–§7) records the method and data that led there; the tables in
+§5–§6 use the pre-change baseline. **Three of the four achromatic anchors named
+in §1's constraint list moved as a result**, so that list states the values as
+they stood when the experiment was designed, not the current ones. Current
+values are always these:
+
+<!-- ANCHORS:BEGIN — checked against contrast() by src/__tests__/docs-lint.spec.ts -->
+
+| pair | OKCA | was, at §1 |
+|---|---:|---:|
+| `#ffffff` on `#000000` | 20.9 | 21.0 |
+| `#000000` on `#ffffff` | 20.0 | 20.0 |
+| `#ffffff` on `#767676` | 3.9 | 3.5 |
+| `#767676` on `#ffffff` | 3.7 | 3.3 |
+
+<!-- ANCHORS:END -->
+
+That table is asserted against the live algorithm in CI, so it cannot drift
+from the code the way the prose below did.
 
 Reproduce all numbers below with:
 
@@ -33,7 +54,10 @@ less conservative **without** giving up its core safety property?
 1. **FP=0 stays hard** — OKCA must never score above WCAG for any sRGB pair
    (with production rounding). Non-negotiable (`OKCA_DESIGN.md` §2.1).
 2. **All 4 achromatic anchors stay fixed** (white/black 21.0, black/white 20.0,
-   white/#767676 3.5, #767676/white 3.3).
+   white/#767676 3.5, #767676/white 3.3). *These are the values as of the
+   experiment's design. The experiment concluded by moving the grey anchor
+   (§8) and a follow-on lowered the light-on-dark cap (§9); three of the four
+   are different today — see the table at the top.*
 3. **Clean-room origin preserved** — no source, formula, or model from any
    external contrast library. The published WCAG 2.x relative-luminance formula
    is exempt (OKCA already references it and reimplements it inline in tests).
@@ -45,7 +69,8 @@ less conservative **without** giving up its core safety property?
 The four constants (`src/index.ts:39-42`) are the only tunable surface. Fixing
 the anchors pins two of them:
 
-- white/#767676 → 3.5 (L-o-D) **pins `POL_K = 1.175`**.
+- white/#767676 → 3.5 (L-o-D) **pins `POL_K = 1.175`**. *(This is the pin the
+  experiment went on to release: the anchor is 3.9 and `POL_K` 1.100 today.)*
 - black/white → 20.0 (D-o-L) **pins `DOL_CAP = 20`** — that pair evaluates to
   $\text{CAP} \cdot (21/21)^{k} = \text{CAP} = 20$.
 

--- a/src/__tests__/docs-lint.spec.ts
+++ b/src/__tests__/docs-lint.spec.ts
@@ -14,8 +14,39 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
+import { contrast } from '../index';
 
 const DOCS_DIR = path.resolve(__dirname, '../../docs');
+
+/**
+ * Docs that quote current anchor values drift silently when the constants are
+ * retuned — CALIBRATION_EXPERIMENT.md carried three stale ones through two
+ * recalibrations, because nothing tied the prose to the code.
+ *
+ * A doc opts in by wrapping a table in `<!-- ANCHORS:BEGIN -->` /
+ * `<!-- ANCHORS:END -->`, with rows shaped:
+ *
+ *     | `#ffffff` on `#000000` | 20.9 | ...ignored... |
+ *
+ * Only the first two columns are read, so a table may carry extra commentary
+ * columns. Returns null when the file has no such block.
+ */
+interface AnchorRow { fg: string; bg: string; quoted: number; line: number }
+
+function findAnchorTable(src: string): AnchorRow[] | null {
+  const begin = src.indexOf('<!-- ANCHORS:BEGIN');
+  if (begin < 0) return null;
+  const end = src.indexOf('<!-- ANCHORS:END', begin);
+  if (end < 0) throw new Error('ANCHORS:BEGIN without a matching ANCHORS:END');
+
+  const before = src.slice(0, begin).split('\n').length;
+  const rows: AnchorRow[] = [];
+  src.slice(begin, end).split('\n').forEach((text, i) => {
+    const m = text.match(/^\s*\|\s*`(#[0-9a-fA-F]{6})`\s+on\s+`(#[0-9a-fA-F]{6})`\s*\|\s*([\d.]+)\s*\|/);
+    if (m) rows.push({ fg: m[1], bg: m[2], quoted: parseFloat(m[3]), line: before + i });
+  });
+  return rows;
+}
 
 const MD_FILES = fs
   .readdirSync(DOCS_DIR)
@@ -172,6 +203,16 @@ describe('docs-lint', () => {
 
     it('has no $ delimiter jammed against " - / or a single *', () => {
       expect(findBadDelimiterAdjacency(lines)).toEqual([]);
+    });
+
+    it('quotes anchor values that match the live algorithm', () => {
+      const rows = findAnchorTable(fs.readFileSync(path.join(DOCS_DIR, filename), 'utf8'));
+      if (rows === null) return; // no ANCHORS block in this file
+      expect(rows.length).toBeGreaterThan(0);
+      for (const { fg, bg, quoted, line } of rows) {
+        expect({ line, pair: `${fg} on ${bg}`, value: contrast(fg, bg) })
+          .toEqual({ line, pair: `${fg} on ${bg}`, value: quoted });
+      }
     });
   });
 });


### PR DESCRIPTION
`CALIBRATION_EXPERIMENT.md` §1 lists the four achromatic anchors as **21.0 / 20.0 / 3.5 / 3.3**. Three are no longer current:

| pair | §1 says | actual |
|---|---:|---:|
| `#ffffff` on `#000000` | 21.0 | **20.9** |
| `#000000` on `#ffffff` | 20.0 | 20.0 |
| `#ffffff` on `#767676` | 3.5 | **3.9** |
| `#767676` on `#ffffff` | 3.3 | **3.7** |

§8 moved the grey anchor to 3.9 (`POL_K` 1.175 → 1.100), which carried `#767676`/white to 3.7, and §9 lowered `LOD_CAP` to 20.9, taking white/black with it.

### Signposted, not rewritten

The list is **not wrong as history** — the experiment genuinely was designed under those constraints, and overwriting the numbers would make §8's "`POL_K` 1.175 → 1.100" read as a change from a value never stated. So the values stay:

- The Status block already covered §8 but was **silent on §9**; it now covers both.
- It carries a table of the four current anchors beside their §1 values.
- §1's constraint 2 and the `POL_K` pin in "What the constraints leave free" get a forward pointer — for readers who arrive on a section anchor and never see the header.

### The part worth keeping

`docs-lint` now parses any table wrapped in `<!-- ANCHORS:BEGIN -->` / `<!-- ANCHORS:END -->` and asserts every quoted value against `contrast()`. Only the first two columns are read, so a table can carry extra commentary columns; docs without the marker are skipped.

Nothing tied this prose to the code, which is why it drifted through two recalibrations unnoticed. A doc that quotes a constant should fail CI when the constant moves.

Verified by injecting the old 3.5 and confirming the suite fails, then restoring. Full suite: 2290 passing.

Related to #22 — §4 already observed that every design-system pair is white-paired, but drew the consequence only for the chroma penalty.