### PR TITLE
docs: state the viewing-condition dependence instead of asserting appearance

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Tested against 1,249 color pairs across three batteries (light-on-dark, dark-on-
 
 **False passes: zero.** OKCA never approves a pair that WCAG rejects.
 
-**WCAG disagreements** are pairs where OKCA scores below 4.5 but WCAG scores ≥ 4.5. These are intentional. WCAG's 4.5:1 AA threshold is widely considered too permissive — white on `#767676` (WCAG's own AA boundary anchor) is not production-ready in most real-world designs. All 97 disagreements involve colors in that marginal zone.
+**WCAG disagreements** are pairs where OKCA scores below 4.5 but WCAG scores ≥ 4.5. These are intentional. WCAG's 4.5:1 AA threshold is widely considered too permissive: white on `#767676` — WCAG's own AA boundary anchor — sits exactly on the line, where the verdict turns on the display and the room rather than on the colors. The same pair can read acceptably on a bright screen and not on a dimmer one ([#22](https://github.com/pawn002/okca/issues/22#issuecomment-5282357292)). A threshold with no margin against viewing conditions is the problem, and all 97 disagreements sit in that zone.
 
 **Found a false pass?** `OKCA ≤ WCAG` is verified across sRGB (`docs/FP0_PROOF.md`). If you somehow find an sRGB pair OKCA scores **above** the WCAG ratio, that's a bug — [open an issue](https://github.com/pawn002/okca/issues) and I'll fix it.
 

--- a/docs/OKCA_DESIGN.md
+++ b/docs/OKCA_DESIGN.md
@@ -263,7 +263,7 @@ Three independent batteries:
 
 **False passes are zero** --- the non-negotiable invariant holds across all 1,249 pairs.
 
-**WCAG disagreements** (pairs where OKCA < 4.5 but WCAG ≥ 4.5) are intentional and should not be read as miscalibration. WCAG's 4.5:1 AA threshold is widely considered too permissive by practitioners. White on `#767676` --- the canonical WCAG AA boundary anchor --- is not production-ready in most real designs. All 97 disagreements involve colours in that marginal zone: proximity to the boundary is not the same as being safely above it. (The count was 111 before the white/#767676 anchor was raised 3.5 → 3.9; that recalibration cleared 14 mid-range chromatics that sat just under 4.5.)
+**WCAG disagreements** (pairs where OKCA < 4.5 but WCAG ≥ 4.5) are intentional and should not be read as miscalibration. WCAG's 4.5:1 AA threshold is widely considered too permissive by practitioners. White on `#767676` --- the canonical WCAG AA boundary anchor --- sits exactly on the line, where the verdict turns on the display and the room rather than on the colours (see *Does not model viewing conditions* in §10 below). All 97 disagreements involve colours in that marginal zone: proximity to the boundary is not the same as being safely above it, and a pair on the line has no margin against the conditions it will be read in. (The count was 111 before the white/#767676 anchor was raised 3.5 → 3.9; that recalibration cleared 14 mid-range chromatics that sat just under 4.5.)
 
 By system: Tailwind CSS v3.4 (34), GOV.UK Design System (13), USWDS v3.x (50). See `docs/WCAG_DISAGREEMENTS.md` for full enumeration with hex values.
 
@@ -300,6 +300,8 @@ Understanding the scope prevents incorrect use and misguided extension attempts.
 **Does not model font size or weight.** WCAG AA (4.5:1) applies uniformly regardless of text size. OKCA outputs a single ratio; size-dependent thresholds are the caller's responsibility.
 
 **Does not replace perceptual judgement.** An OKCA score of 4.5 on a warm fuchsia text/white background means the pair clears the numerical threshold. A designer may still find it unpleasant. OKCA is a safety floor, not a design recommendation.
+
+**Does not model viewing conditions.** The contrast at which text becomes acceptable moves substantially with display luminance and ambient light — far enough that a pair near the AA boundary can be judged shippable under one setup and not another by the same person in the same room ([#22](https://github.com/pawn002/okca/issues/22#issuecomment-5282357292)). OKCA is a relative metric over sRGB with no access to absolute luminance, so it does not model this and no constant of its own could: a level-dependent term was measured for and not detected, while the effect that does exist tracks a quantity the algorithm cannot observe. The safety bound is unaffected, being a relation between two relative metrics. The practical consequence is that OKCA's floors are viewing-condition independent by construction, which is a reason to keep them conservative rather than to tune them.
 
 **Does not patch WCAG's channel weighting.** OKCA does not compensate for the IEC 61966-2-1 green-channel weighting in WCAG's luminance formula. The chroma compression is rotationally symmetric in ab-space — no hue branch, no asymmetric treatment of $a$ vs $b$. Hue-varying outcomes arise from Oklab geometry (different hues reach different C values at similar lightness), not from explicit hue targeting.
 

--- a/docs/WCAG_DISAGREEMENTS.md
+++ b/docs/WCAG_DISAGREEMENTS.md
@@ -49,7 +49,7 @@ The 500-level neutral greys are the most practically significant: designers reac
 | pink-600 | `#db2777` | 4.6 | 3.5 | 3.3 |  |
 | rose-600 | `#e11d48` | 4.7 | 3.5 | 3.4 |  |
 
-**Pattern:** The Tailwind neutral 500 scale lands at WCAG ~4.7–4.8 but OKCA scores it 3.9–4.2 — a designer would generally not call any of these comfortable for body text on white. Magenta-adjacent hues (fuchsia-600, pink-600 at 3.5/3.3) carry the largest chroma-compression penalty. The deep-700 greens (lime, green) clear AA with white text on them (L-o-D) but still fall just short as text on white (D-o-L).
+**Pattern:** The Tailwind neutral 500 scale lands at WCAG ~4.7–4.8 but OKCA scores it 3.9–4.2 — squarely in the zone where whether a pair reads comfortably as body text turns on the viewing conditions rather than on the pair (see *Practitioner benchmark* below). Magenta-adjacent hues (fuchsia-600, pink-600 at 3.5/3.3) carry the largest chroma-compression penalty. The deep-700 greens (lime, green) clear AA with white text on them (L-o-D) but still fall just short as text on white (D-o-L).
 
 ---
 
@@ -126,3 +126,7 @@ Most colours appear as both a L-o-D and D-o-L failure. The polarity model means 
 
 ### Practitioner benchmark
 The canonical marginal pair — white on `#767676` — scores WCAG 4.5, OKCA 3.9 (L-o-D). Everything in this document is in the same zone or worse. A designer who accepts `#767676` as passing AA is accepting the same risk for every entry here.
+
+That risk is not a matter of taste. In a threshold experiment reported in [#22](https://github.com/pawn002/okca/issues/22#issuecomment-5282357292), the contrast at which body text was judged shippable measured **5.2 at one display brightness and 2.8 at another** — same observer, same room, same session. OKCA 3.9 falls between those two figures, so the verdict on this exact pair inverts across ordinary viewing conditions.
+
+That is n = 1 and a single datum, not a population estimate, and it is quoted here for direction rather than magnitude. The direction is the point: a pair sitting on the AA line carries no margin against the conditions it will actually be read in. That is an argument for a floor above the line rather than at it — and it is a stronger argument for OKCA's conservatism than any claim about how a given pair looks, because it does not depend on anyone agreeing about appearance.


### PR DESCRIPTION
Four places in the docs claimed how a marginal pair *looks*, in absolute terms:

- `README.md` and `docs/OKCA_DESIGN.md` §8 — white on `#767676` "is not production-ready in most real designs"
- `docs/WCAG_DISAGREEMENTS.md` — "a designer would generally not call any of these comfortable for body text on white"

Those are not supportable as written, and the measurement is now public. The threshold experiment reported in #22 put the contrast at which body text was judged shippable at **5.2 under one display brightness and 2.8 under another** — same observer, same room, same session. OKCA scores white on `#767676` at **3.9**, which falls between them. The verdict on the exact pair the docs single out inverts across ordinary viewing conditions.

### This is not a hedge

The absolute claim was never load-bearing. OKCA's argument is directional (`OKCA ≤ WCAG`) and comparative (stricter in the marginal zone); neither needs anyone to agree about appearance.

What replaces it is stronger: a pair sitting on the AA line has **no margin against the conditions it will actually be read in**. That argues for a floor above the line on variance grounds rather than on taste — and unlike the old wording, it is backed by a measurement and cannot be waved off as one person's eye.

### Changes

| file | change |
|---|---|
| `README.md` | absolute verdict → viewing-condition dependence, cites #22 |
| `docs/OKCA_DESIGN.md` §8 | same, cross-referenced to §10 |
| `docs/OKCA_DESIGN.md` §10 | **new limit: "Does not model viewing conditions"** |
| `docs/WCAG_DISAGREEMENTS.md` | pattern note reworded; *Practitioner benchmark* carries the measurement |

The §10 addition is the structural fix, sitting next to the existing "does not replace perceptual judgement" limit: OKCA is relative over sRGB, has no access to absolute luminance, and no constant of its own could carry this — a level-dependent term was measured for and not detected, while the effect that does exist tracks a quantity the algorithm cannot observe.

### Scope

**The safety bound is untouched.** `OKCA ≤ WCAG` relates two relative metrics over the sRGB gamut and carries no perceptual or viewing-condition premise. Nothing here weakens FP=0, and no algorithm code changes.

`n = 1` is stated plainly at the one place the numbers are quoted, and they are quoted for direction rather than magnitude.

Docs-only. 2290 tests pass locally, including the docs-lint anchor guard from #23.